### PR TITLE
HOTFIX: Parameter Weighting

### DIFF
--- a/Assets/Core/HeartratePlugin.cs
+++ b/Assets/Core/HeartratePlugin.cs
@@ -101,6 +101,7 @@ public class HeartratePlugin : VTSPlugin
                 (s) => {
                     _linear.id = PARAMETER_LINEAR;
                     _linear.value = 0;
+                    _linear.weight = 1;
                     _paramValues.Add(_linear);
                 },
                 (e) => {
@@ -110,6 +111,7 @@ public class HeartratePlugin : VTSPlugin
                 (s) => {
                     _pulse.id = PARAMETER_SINE_PULSE;
                     _pulse.value = 0;
+                    _pulse.weight = 1;
                     _paramValues.Add(_pulse);
                 },
                 (e) => {
@@ -119,6 +121,7 @@ public class HeartratePlugin : VTSPlugin
                 (s) => {
                     _breath.id = PARAMETER_SINE_BREATH;
                     _breath.value = 0;
+                    _breath.weight = 1;
                     _paramValues.Add(_breath);
                 },
                 (e) => {
@@ -128,6 +131,7 @@ public class HeartratePlugin : VTSPlugin
                 (s) => {
                     _bpm.id = PARAMETER_BPM;
                     _bpm.value = 0;
+                    _bpm.weight = 1;
                     _paramValues.Add(_bpm);
                 },
                 (e) => {
@@ -178,8 +182,9 @@ public class HeartratePlugin : VTSPlugin
         int priorHeartrate = this._heartRate;
         this._average.AddValue(this._activeModule != null ? this._activeModule.GetHeartrate() : 0);
         this._heartRate = Mathf.RoundToInt(this._average.Average);
-        float interpolation = Mathf.Clamp01((float)(this._heartRate-this._minRate)/(float)(this._maxRate - this._minRate));
-
+        float numerator =  Math.Max(0, (float)(this._heartRate-this._minRate));
+        float demominator = Math.Max(1, (float)(this._maxRate - this._minRate));
+        float interpolation = Mathf.Clamp01(numerator/demominator);
         if(this.IsAuthenticated){
             // see which model is currently loaded
             GetCurrentModel(
@@ -258,7 +263,7 @@ public class HeartratePlugin : VTSPlugin
                     InjectedParamValuesToDictionary(_paramValues.ToArray());
                 },
                 (e) => {
-                    Debug.Log(JsonUtility.ToJson(e));
+                    Debug.LogError(JsonUtility.ToJson(e));
                 });
             }
         }

--- a/Assets/Core/VTS/VTSPlugin.cs
+++ b/Assets/Core/VTS/VTSPlugin.cs
@@ -160,6 +160,7 @@ namespace VTS {
             authRequest.data.pluginName = this._pluginName;
             authRequest.data.pluginDeveloper = this._pluginAuthor;
             authRequest.data.authenticationToken = this._token;
+            authRequest.data.pluginIcon = EncodeIcon(this.PluginIcon);
             this._socket.Send<VTSAuthData>(authRequest, onSuccess, onError);
         }
 

--- a/Assets/Tools/Screenshotter.cs
+++ b/Assets/Tools/Screenshotter.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using System;
+using System.IO;
+
+public class Screenshotter : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        if(Input.GetKeyDown(KeyCode.P)){
+            var timeSpan = (DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0));
+            UnityEngine.ScreenCapture.CaptureScreenshot(Path.Combine(Application.persistentDataPath, ((long)timeSpan.TotalSeconds)+".png"), 1);
+        }
+    }
+}

--- a/Assets/Tools/Screenshotter.cs.meta
+++ b/Assets/Tools/Screenshotter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d0490cfcae4512c4c96768d52826af6e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UI/Prefabs/Modules/Heartrate Input Components/Threshold Settings.prefab
+++ b/Assets/UI/Prefabs/Modules/Heartrate Input Components/Threshold Settings.prefab
@@ -327,6 +327,21 @@ PrefabInstance:
       propertyPath: m_enableAutoSizing
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 329366328989190386, guid: 7aa98a72e703362429617be53603a2ef,
+        type: 3}
+      propertyPath: m_ContentType
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 329366328989190386, guid: 7aa98a72e703362429617be53603a2ef,
+        type: 3}
+      propertyPath: m_KeyboardType
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 329366328989190386, guid: 7aa98a72e703362429617be53603a2ef,
+        type: 3}
+      propertyPath: m_CharacterValidation
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 390429076480021513, guid: 7aa98a72e703362429617be53603a2ef,
         type: 3}
       propertyPath: m_AnchorMin.x
@@ -705,6 +720,21 @@ PrefabInstance:
         type: 3}
       propertyPath: m_enableAutoSizing
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 329366328989190386, guid: 7aa98a72e703362429617be53603a2ef,
+        type: 3}
+      propertyPath: m_ContentType
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 329366328989190386, guid: 7aa98a72e703362429617be53603a2ef,
+        type: 3}
+      propertyPath: m_KeyboardType
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 329366328989190386, guid: 7aa98a72e703362429617be53603a2ef,
+        type: 3}
+      propertyPath: m_CharacterValidation
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 390429076480021513, guid: 7aa98a72e703362429617be53603a2ef,
         type: 3}

--- a/Assets/UI/Scripts/Modules/Heartrate Inputs/HeartrateRangesInputModule.cs
+++ b/Assets/UI/Scripts/Modules/Heartrate Inputs/HeartrateRangesInputModule.cs
@@ -29,7 +29,7 @@ public class HeartrateRangesInputModule : MonoBehaviour
 
     private int RateToInt(string rate){
         try{
-            return int.Parse(rate);
+            return Mathf.Clamp(int.Parse(rate), 0, 255);
         }catch(System.Exception e){
             Debug.LogWarning(e);
         }

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -124,7 +124,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 1.1.0
+  bundleVersion: 1.1.1
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0


### PR DESCRIPTION
This hotfix fixes:

- VTS throwing errors indicating that it cannot determine parameter weight
- Case where custom parameter interpolation value could be negative (if heartrate minimum was set to be greater than the max, or if both were zero)
