### PR TITLE
FEATURE: Overhead Reduction

### DIFF
--- a/Assets/Core/HeartrateManager.cs
+++ b/Assets/Core/HeartrateManager.cs
@@ -52,7 +52,7 @@ public class HeartrateManager : Singleton<HeartrateManager>
                     Localization.LocalizationManager.Instance.AddStrings(strings, Localization.LocalizationManager.Instance.CurrentLanguage);
                     UIManager.Instance.ShowPopUp(
                         "settings_new_version_title",
-                        string.Format("settings_new_version_body_populated", info.version, info.date, info.url),
+                        "settings_new_version_body_populated",
                         new PopUp.PopUpOption(
                             "settings_new_version_button_download", 
                             ColorUtils.ColorPreset.GREEN, 

--- a/Assets/Core/Managers.prefab
+++ b/Assets/Core/Managers.prefab
@@ -27,6 +27,7 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 4104924829136204198}
   - {fileID: 1168434495776635000}
   - {fileID: 1168434496851292184}
   - {fileID: 2958236444935304371}
@@ -50,7 +51,7 @@ PrefabInstance:
     - target: {fileID: 554069957939498263, guid: 7951643150dd6724f91862104e3b5c06,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 554069957939498263, guid: 7951643150dd6724f91862104e3b5c06,
         type: 3}
@@ -130,7 +131,7 @@ PrefabInstance:
     - target: {fileID: 2332643205868092403, guid: 44ebefc6a7d9b884fadf5f995457cd70,
         type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 2332643205868092403, guid: 44ebefc6a7d9b884fadf5f995457cd70,
         type: 3}
@@ -251,6 +252,81 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 893207687841272490}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1161917240773522064
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1168434495382978284}
+    m_Modifications:
+    - target: {fileID: 2947723539784729396, guid: ae4321cbfba9e1c419cf97ad084e7537,
+        type: 3}
+      propertyPath: m_Name
+      value: Logging Manager
+      objectReference: {fileID: 0}
+    - target: {fileID: 2947723539784729398, guid: ae4321cbfba9e1c419cf97ad084e7537,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2947723539784729398, guid: ae4321cbfba9e1c419cf97ad084e7537,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2947723539784729398, guid: ae4321cbfba9e1c419cf97ad084e7537,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2947723539784729398, guid: ae4321cbfba9e1c419cf97ad084e7537,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2947723539784729398, guid: ae4321cbfba9e1c419cf97ad084e7537,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2947723539784729398, guid: ae4321cbfba9e1c419cf97ad084e7537,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2947723539784729398, guid: ae4321cbfba9e1c419cf97ad084e7537,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2947723539784729398, guid: ae4321cbfba9e1c419cf97ad084e7537,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2947723539784729398, guid: ae4321cbfba9e1c419cf97ad084e7537,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2947723539784729398, guid: ae4321cbfba9e1c419cf97ad084e7537,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2947723539784729398, guid: ae4321cbfba9e1c419cf97ad084e7537,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ae4321cbfba9e1c419cf97ad084e7537, type: 3}
+--- !u!4 &4104924829136204198 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2947723539784729398, guid: ae4321cbfba9e1c419cf97ad084e7537,
+    type: 3}
+  m_PrefabInstance: {fileID: 1161917240773522064}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5297901458195327869
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -261,7 +337,7 @@ PrefabInstance:
     - target: {fileID: 5806722320210425693, guid: b706d543aa5c27d49b0516471dad29c4,
         type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 5806722320210425693, guid: b706d543aa5c27d49b0516471dad29c4,
         type: 3}
@@ -336,7 +412,7 @@ PrefabInstance:
     - target: {fileID: 5264776173987455105, guid: c3f12fc3886f47c428327281bb5b80f9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 5264776173987455105, guid: c3f12fc3886f47c428327281bb5b80f9,
         type: 3}
@@ -421,7 +497,7 @@ PrefabInstance:
     - target: {fileID: 3572055464049073184, guid: 95fd351bd06318347a2cc4cb59a75f39,
         type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 3572055464049073184, guid: 95fd351bd06318347a2cc4cb59a75f39,
         type: 3}
@@ -501,7 +577,7 @@ PrefabInstance:
     - target: {fileID: 5496125887797148255, guid: 25a76494cadfdbf4bbae265175716c39,
         type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 5496125887797148255, guid: 25a76494cadfdbf4bbae265175716c39,
         type: 3}
@@ -576,7 +652,7 @@ PrefabInstance:
     - target: {fileID: 8987925111482354569, guid: 84aa038bec48fc147a502ce8220001bb,
         type: 3}
       propertyPath: m_RootOrder
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8987925111482354569, guid: 84aa038bec48fc147a502ce8220001bb,
         type: 3}
@@ -701,7 +777,7 @@ PrefabInstance:
     - target: {fileID: 9180223014055572702, guid: 9654e70d6e2a7f64aacf0fd880a609ba,
         type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 9180223014055572702, guid: 9654e70d6e2a7f64aacf0fd880a609ba,
         type: 3}
@@ -776,7 +852,7 @@ PrefabInstance:
     - target: {fileID: 8673949549226734510, guid: 35132f1f3c92a23449130e8b5ba7a7d3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 8673949549226734510, guid: 35132f1f3c92a23449130e8b5ba7a7d3,
         type: 3}
@@ -851,7 +927,7 @@ PrefabInstance:
     - target: {fileID: 5512966710406100380, guid: d05bb44cae341e244b6e88f3bc24c310,
         type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 5512966710406100380, guid: d05bb44cae341e244b6e88f3bc24c310,
         type: 3}

--- a/Assets/Core/VTS/Enums/ErrorID.cs
+++ b/Assets/Core/VTS/Enums/ErrorID.cs
@@ -1,10 +1,8 @@
-﻿namespace VTS{
+﻿namespace VTS {
     /// <summary>
     /// Enum for API-related errors.
     /// </summary>
-    [System.Serializable]
-    public enum ErrorID : int
-    {
+    public enum ErrorID {
         // General errors
         InternalServerError = 0,
         APIAccessDeactivated = 1,
@@ -36,13 +34,15 @@
         CannotCurrentlyChangeModel = 154,
 
         // Errors related to HotkeyTriggerRequest
-        HotkeyQueueFull = 200, // 
+        HotkeyQueueFull = 200, // Only a certain amount of hotkey activations can be queued until you have to wait for execution completion.
         HotkeyExecutionFailedBecauseNoModelLoaded = 201,
         HotkeyIDNotFoundInModel = 202,
         HotkeyCooldownNotOver = 203, // Individual hotkeys have a global 5 second cooldown
         HotkeyIDFoundButHotkeyDataInvalid = 204, // For example missing files for expression/animation hotkey
         HotkeyExecutionFailedBecauseBadState = 205, // For example when trying to load a model and the user has certain config windows open that temporarily prevent that
         HotkeyUnknownExecutionFailure = 206,
+        HotkeyExecutionFailedBecauseLive2DItemNotFound = 207, // When triggering hotkeys in Live2D items, this will be returned if the requested Live2D item has not been found.
+        HotkeyExecutionFailedBecauseLive2DItemsDoNotSupportThisHotkeyType = 208, // Only a subset of hotkey actions are supported in Live2D items, for example Expression hotkeys.
         
         // Errors related to ColorTintRequest
         ColorTintRequestNoModelLoaded = 250,
@@ -75,8 +75,70 @@
         InjectDataWeightInvalid = 452,
         InjectDataParamNameNotFound = 453, // Trying to send data for parameter that doesn't exist
         InjectDataParamControlledByOtherPlugin = 454, // Only one plugin can send data for a parameter at a time
+        InjectDataModeUnknown = 455, // Only "add" and "set" can be used. If no mode is provided, "set" will be used.
         
         // Errors related to ParameterValueRequest
-        ParameterValueRequestParameterNotFound = 500
+        ParameterValueRequestParameterNotFound = 500,
+
+        // Errors related to NDIConfigRequest
+        NDIConfigCooldownNotOver = 550,
+        NDIConfigResolutionInvalid = 551,
+
+        // Errors related to ExpressionStateRequest
+        ExpressionStateRequestInvalidFilename = 600,
+        ExpressionStateRequestFileNotFound = 601,
+
+        // Errors related to ExpressionStateRequest
+        ExpressionActivationRequestInvalidFilename = 650,
+        ExpressionActivationRequestFileNotFound = 651,
+        ExpressionActivationRequestNoModelLoaded = 652,
+        
+        // Errors related to SetCurrentModelPhysicsRequest
+        SetCurrentModelPhysicsRequestNoModelLoaded = 700,
+        SetCurrentModelPhysicsRequestModelHasNoPhysics = 701,
+        SetCurrentModelPhysicsRequestPhysicsControlledByOtherPlugin = 702, 
+        SetCurrentModelPhysicsRequestNoOverridesProvided = 703,
+        SetCurrentModelPhysicsRequestPhysicsGroupIDNotFound = 704,
+        SetCurrentModelPhysicsRequestNoOverrideValueProvided = 705,
+        SetCurrentModelPhysicsRequestDuplicatePhysicsGroupID = 706,
+        
+        // Errors related to ItemLoadRequest
+        ItemFileNameMissing = 750,
+        ItemFileNameNotFound = 751,
+        ItemLoadLoadCooldownNotOver = 752, // Not used anymore. The cooldown for loading items has been removed.
+        CannotCurrentlyLoadItem = 753, // This is usually because the user has menus open that prevent items from being loaded.
+        CannotLoadItemSceneFull = 754,
+        ItemOrderInvalid = 755,
+        ItemOrderAlreadyTaken = 756,
+        ItemLoadValuesInvalid = 757, // Invalid values for fields like size, position, ...
+
+        // Errors related to ItemUnloadRequest
+        CannotCurrentlyUnloadItem = 800,  // This is usually because the user has menus open that prevent items from being unloaded.
+
+        // Errors related to ItemAnimationControlRequest
+        ItemAnimationControlInstanceIDNotFound = 850,
+        ItemAnimationControlUnsupportedItemType = 851, // Returned when trying to use this request for Live2D items.
+        ItemAnimationControlAutoStopFramesInvalid = 852, // Auto-stop frames indices have to be between 0 and the last frame index of the animated item.
+        ItemAnimationControlTooManyAutoStopFrames = 853, // Maximum allowed number per item is 1024.
+        ItemAnimationControlSimpleImageDoesNotSupportAnim = 854, // You can set stuff like transparency and brightness for normal PNG/JPG items, but nothing animation-related.
+
+        // Errors related to ItemMoveRequest
+        ItemMoveRequestInstanceIDNotFound = 900,
+        ItemMoveRequestInvalidFadeMode = 901,
+        ItemMoveRequestItemOrderTakenOrInvalid = 902,
+        ItemMoveRequestCannotCurrentlyChangeOrder = 903, // Cannot change order when any windows are open.
+        
+        // Errors related to EventSubscriptionRequest
+        EventSubscriptionRequestEventTypeUnknown = 950,
+        
+        // -------------- EVENT CONFIG ERRORS --------------
+        
+        EVENT_OFFSET = 100000,
+
+        // Event subscription errors for TestEvent
+        Event_TestEvent_TestMessageTooLong = EVENT_OFFSET + 0,
+
+        // Event subscription errors for ModelLoadedEvent
+        Event_ModelLoadedEvent_ModelIDInvalid = EVENT_OFFSET + 50
     }
 }

--- a/Assets/Core/VTS/Enums/ErrorID.cs
+++ b/Assets/Core/VTS/Enums/ErrorID.cs
@@ -2,7 +2,8 @@
     /// <summary>
     /// Enum for API-related errors.
     /// </summary>
-    public enum ErrorID {
+    public enum ErrorID
+    {
         // General errors
         InternalServerError = 0,
         APIAccessDeactivated = 1,

--- a/Assets/Core/VTS/Enums/HotkeyAction.cs
+++ b/Assets/Core/VTS/Enums/HotkeyAction.cs
@@ -1,24 +1,25 @@
-﻿namespace VTS{
+﻿namespace VTS {
     /// <summary>
     /// Enum for the actions that can be triggered by hotkeys.
     /// </summary>
     [System.Serializable]
     public enum HotkeyAction : int
     {
-        Unset = -1,                  // Unset.
-        TriggerAnimation = 0,        // Play an animation.
-        ChangeIdleAnimation = 1,     // Change the idle animation.
-        ToggleExpression = 2,        // Toggle an expression.
-        RemoveAllExpressions = 3,    // Remove all expressions.
-        MoveModel = 4,               // Moves the model to the target position.
-        ChangeBackground = 5,        // Change the current background.
-        ReloadMicrophone = 6,        // Reload the current microphone.
-        ReloadTextures = 7,          // Reload the model texture.
-        CalibrateCam = 8,            // Calibrate Camera.
-        ChangeVTSModel = 9,          // Change VTS Model.
-        TakeScreenshot = 10,         // Takes a screenshot with the screenshot settings previously set in the UI.
-        ScreenColorOverlay = 11,     // Activates/Deactivates model screen color overlay.
-        RemoveAllItems = 12,         // Removes items from the scene.
-        ToggleItemScene = 13         // Toggles an item scene.
+        Unset = -1,                       // Unset.
+        TriggerAnimation = 0,             // Play an animation.
+        ChangeIdleAnimation = 1,          // Change the idle animation.
+        ToggleExpression = 2,             // Toggle an expression.
+        RemoveAllExpressions = 3,         // Remove all expressions.
+        MoveModel = 4,                    // Moves the model to the target position.
+        ChangeBackground = 5,             // Change the current background.
+        ReloadMicrophone = 6,             // Reload the current microphone.
+        ReloadTextures = 7,               // Reload the model texture.
+        CalibrateCam = 8,                 // Calibrate Camera.
+        ChangeVTSModel = 9,               // Change VTS Model.
+        TakeScreenshot = 10,              // Take a screenshot with the previous settings.
+        ScreenColorOverlay = 11,          // Activates/Deactivates model screen color overlay.
+        DownloadRandomWorkshopItem = 14,  // Downloads a random item from the Steam Workshop and attempts to load it into the scene.
+        ExecuteItemAction = 15,           // Executes a hotkey in the given Live2D item.
+        ArtMeshColorPreset = 16           // Loads the recorded ArtMesh multiply/screen color preset.
     }
 }

--- a/Assets/Core/VTS/Enums/HotkeyAction.cs
+++ b/Assets/Core/VTS/Enums/HotkeyAction.cs
@@ -3,7 +3,7 @@
     /// Enum for the actions that can be triggered by hotkeys.
     /// </summary>
     [System.Serializable]
-    public enum HotkeyAction : int
+    public enum HotkeyAction
     {
         Unset = -1,                       // Unset.
         TriggerAnimation = 0,             // Play an animation.
@@ -20,6 +20,7 @@
         ScreenColorOverlay = 11,          // Activates/Deactivates model screen color overlay.
         DownloadRandomWorkshopItem = 14,  // Downloads a random item from the Steam Workshop and attempts to load it into the scene.
         ExecuteItemAction = 15,           // Executes a hotkey in the given Live2D item.
-        ArtMeshColorPreset = 16           // Loads the recorded ArtMesh multiply/screen color preset.
+        ArtMeshColorPreset = 16,          // Loads the recorded ArtMesh multiply/screen color preset.
+        ToggleTracker = 17                // Toggles the tracking on/off. Can be webcam or USB/WiFi connected phone.
     }
 }

--- a/Assets/Core/VTS/Models/JsonUtilityImpl.cs
+++ b/Assets/Core/VTS/Models/JsonUtilityImpl.cs
@@ -1,4 +1,4 @@
-﻿namespace VTS.Models.Impl{
+﻿namespace VTS.Models.Impl{  
     public class JsonUtilityImpl : IJsonUtility
     {
         public T FromJson<T>(string json)
@@ -54,7 +54,7 @@
                 if(pair.Length > 1){
                     float nullable = 0.0f;
                     float.TryParse(pair[1], out nullable);
-                    if(float.MinValue.Equals(nullable)){
+                    if("NaN".Equals(pair[1]) || float.MinValue.Equals(nullable) || int.MinValue.Equals(nullable)){
                         output = output.Replace(prop+",", "");
                         output = output.Replace(prop, "");
                     }

--- a/Assets/Core/VTS/Models/VTSData.cs
+++ b/Assets/Core/VTS/Models/VTSData.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 
 namespace VTS.Models {
-    public class VTSMessageData
-    {
+
+    #region Common
+
+    [System.Serializable]
+    public class VTSMessageData {
         public string apiName = "VTubeStudioPublicAPI";
         public long timestamp;
         public string apiVersion = "1.0";
@@ -11,7 +14,7 @@ namespace VTS.Models {
     }
 
     [System.Serializable]
-    public class VTSErrorData : VTSMessageData{
+    public class VTSErrorData : VTSMessageData {
          public VTSErrorData(){
             this.messageType = "APIError";
             this.data = new Data();
@@ -26,7 +29,17 @@ namespace VTS.Models {
     }
 
     [System.Serializable]
-    public class VTSStateData : VTSMessageData{
+    public struct Pair {
+        public float x;
+        public float y;
+    }
+
+    #endregion
+
+    #region General API
+
+    [System.Serializable]
+    public class VTSStateData : VTSMessageData {
         public VTSStateData(){
             this.messageType = "APIStateRequest";
             this.data = new Data();
@@ -34,7 +47,7 @@ namespace VTS.Models {
         public Data data;
 
         [System.Serializable]
-        public class Data{
+        public class Data {
             public bool active;
             public string vTubeStudioVersion;
             public bool currentSessionAuthenticated;
@@ -42,7 +55,7 @@ namespace VTS.Models {
     }
 
     [System.Serializable]
-    public class VTSAuthData : VTSMessageData{
+    public class VTSAuthData : VTSMessageData {
         public VTSAuthData(){
             this.messageType = "AuthenticationTokenRequest";
             this.data = new Data();
@@ -61,7 +74,7 @@ namespace VTS.Models {
     }
 
     [System.Serializable]
-    public class VTSStatisticsData : VTSMessageData{
+    public class VTSStatisticsData : VTSMessageData {
          public VTSStatisticsData(){
             this.messageType = "StatisticsRequest";
             this.data = new Data();
@@ -82,7 +95,7 @@ namespace VTS.Models {
     }
 
     [System.Serializable]
-    public class VTSFolderInfoData : VTSMessageData{
+    public class VTSFolderInfoData : VTSMessageData {
          public VTSFolderInfoData(){
             this.messageType = "VTSFolderInfoRequestuest";
             this.data = new Data();
@@ -101,25 +114,29 @@ namespace VTS.Models {
     }
 
     [System.Serializable]
-    public class VTSModelData {
+    public class ModelData {
         public bool modelLoaded;
         public string modelName;
         public string modelID;
+    }
+
+    [System.Serializable]
+    public class VTSModelData : ModelData {
         public string vtsModelName;
         public string vtsModelIconName;
     }
 
     [System.Serializable]
-    public class ModelPosition{
-        public float positionX = float.MinValue;
-        public float positionY = float.MinValue;
-        public float rotation = float.MinValue;
-        public float size = float.MinValue;
+    public class ModelPosition {
+        public float positionX = float.NaN;
+        public float positionY = float.NaN;
+        public float rotation = float.NaN;
+        public float size = float.NaN;
 
     }
 
     [System.Serializable]
-    public class VTSCurrentModelData : VTSMessageData{
+    public class VTSCurrentModelData : VTSMessageData {
          public VTSCurrentModelData(){
             this.messageType = "CurrentModelRequest";
             this.data = new Data();
@@ -127,7 +144,7 @@ namespace VTS.Models {
         public Data data;
 
         [System.Serializable]
-        public class Data : VTSModelData{
+        public class Data : VTSModelData {
 		    public string live2DModelName;
 		    public long modelLoadTime;
 		    public long timeSinceModelLoaded;
@@ -142,7 +159,7 @@ namespace VTS.Models {
     }
 
     [System.Serializable]
-    public class VTSAvailableModelsData : VTSMessageData{
+    public class VTSAvailableModelsData : VTSMessageData {
          public VTSAvailableModelsData(){
             this.messageType = "AvailableModelsRequest";
             this.data = new Data();
@@ -157,7 +174,7 @@ namespace VTS.Models {
     }
 
     [System.Serializable]
-    public class VTSModelLoadData : VTSMessageData{
+    public class VTSModelLoadData : VTSMessageData {
         public VTSModelLoadData(){
             this.messageType = "ModelLoadRequest";
             this.data = new Data();
@@ -171,7 +188,7 @@ namespace VTS.Models {
     }
 
     [System.Serializable]
-    public class VTSMoveModelData : VTSMessageData{
+    public class VTSMoveModelData : VTSMessageData {
         public VTSMoveModelData(){
             this.messageType = "MoveModelRequest";
             this.data = new Data();
@@ -194,7 +211,7 @@ namespace VTS.Models {
     }
 
     [System.Serializable]
-    public class VTSHotkeysInCurrentModelData : VTSMessageData{
+    public class VTSHotkeysInCurrentModelData : VTSMessageData {
         public VTSHotkeysInCurrentModelData(){
             this.messageType = "HotkeysInCurrentModelRequest";
             this.data = new Data();
@@ -206,12 +223,13 @@ namespace VTS.Models {
             public bool modelLoaded;
             public string modelName;
             public string modelID;
+            public string live2DItemFileName;
             public HotkeyData[] availableHotkeys;
         }
     }
 
     [System.Serializable]
-    public class VTSHotkeyTriggerData : VTSMessageData{
+    public class VTSHotkeyTriggerData : VTSMessageData {
         public VTSHotkeyTriggerData(){
             this.messageType = "HotkeyTriggerRequest";
             this.data = new Data();
@@ -221,11 +239,12 @@ namespace VTS.Models {
         [System.Serializable]
         public class Data {
             public string hotkeyID;
+            public string itemInstanceID;
         }
     }
 
     [System.Serializable]
-    public class VTSArtMeshListData : VTSMessageData{
+    public class VTSArtMeshListData : VTSMessageData {
         public VTSArtMeshListData(){
             this.messageType = "ArtMeshListRequest";
             this.data = new Data();
@@ -254,7 +273,7 @@ namespace VTS.Models {
         /// Converts the color into a Unity color struct.
         /// </summary>
         /// <returns></returns>
-        public UnityEngine.Color32 toColor32(){
+        public UnityEngine.Color32 ToColor32(){
             return new UnityEngine.Color32(colorR, colorG, colorB, colorA);
         }
 
@@ -262,7 +281,7 @@ namespace VTS.Models {
         /// Loads color data from a Unity color struct
         /// </summary>
         /// <param name="color"></param>
-        public void fromColor32(UnityEngine.Color32 color){
+        public void FromColor32(UnityEngine.Color32 color){
             this.colorA = color.a;
             this.colorB = color.b;
             this.colorG = color.g;
@@ -271,7 +290,7 @@ namespace VTS.Models {
     }
 
     [System.Serializable]
-    public class ArtMeshColorTint : ColorTint{
+    public class ArtMeshColorTint : ColorTint {
         public float mixWithSceneLightingColor = 1.0f;
     }
 
@@ -286,7 +305,7 @@ namespace VTS.Models {
     }
 
     [System.Serializable]
-    public class VTSColorTintData : VTSMessageData{
+    public class VTSColorTintData : VTSMessageData {
         public VTSColorTintData(){
             this.messageType = "ColorTintRequest";
             this.data = new Data();
@@ -307,7 +326,7 @@ namespace VTS.Models {
     }
 
     [System.Serializable]
-    public class VTSSceneColorOverlayData : VTSMessageData{
+    public class VTSSceneColorOverlayData : VTSMessageData {
         public VTSSceneColorOverlayData(){
             this.messageType = "SceneColorOverlayInfoRequest";
             this.data = new Data();
@@ -332,7 +351,7 @@ namespace VTS.Models {
     }
 
     [System.Serializable]
-    public class VTSFaceFoundData : VTSMessageData{
+    public class VTSFaceFoundData : VTSMessageData {
         public VTSFaceFoundData(){
             this.messageType = "FaceFoundRequest";
             this.data = new Data();
@@ -356,7 +375,7 @@ namespace VTS.Models {
     }
 
     [System.Serializable]
-    public class VTSInputParameterListData : VTSMessageData{
+    public class VTSInputParameterListData : VTSMessageData {
         public VTSInputParameterListData(){
             this.messageType = "InputParameterListRequest";
             this.data = new Data();
@@ -374,7 +393,7 @@ namespace VTS.Models {
     }
 
     [System.Serializable]
-    public class VTSParameterValueData : VTSMessageData{
+    public class VTSParameterValueData : VTSMessageData {
         public VTSParameterValueData(){
             this.messageType = "ParameterValueRequest";
             this.data = new Data();
@@ -386,7 +405,7 @@ namespace VTS.Models {
     }
 
     [System.Serializable]
-    public class VTSLive2DParameterListData : VTSMessageData{
+    public class VTSLive2DParameterListData : VTSMessageData {
         public VTSLive2DParameterListData(){
             this.messageType = "Live2DParameterListRequest";
             this.data = new Data();
@@ -413,7 +432,7 @@ namespace VTS.Models {
     }
 
     [System.Serializable]
-    public class VTSParameterCreationData : VTSMessageData{
+    public class VTSParameterCreationData : VTSMessageData {
         public VTSParameterCreationData(){
             this.messageType = "ParameterCreationRequest";
             this.data = new Data();
@@ -425,7 +444,7 @@ namespace VTS.Models {
     }
 
     [System.Serializable]
-    public class VTSParameterDeletionData : VTSMessageData{
+    public class VTSParameterDeletionData : VTSMessageData {
         public VTSParameterDeletionData(){
             this.messageType = "ParameterDeletionRequest";
             this.data = new Data();
@@ -439,14 +458,21 @@ namespace VTS.Models {
     }
 
     [System.Serializable]
-    public class VTSParameterInjectionValue{
+    public class VTSParameterInjectionValue {
         public string id;
-        public float value = float.MinValue;
-        public float weight = float.MinValue;
+        public float value = float.NaN;
+        public float weight = float.NaN;
     }
 
     [System.Serializable]
-    public class VTSInjectParameterData : VTSMessageData{
+    public enum VTSInjectParameterMode : int {
+        UNKNOWN = -1,
+        SET = 0,
+        ADD = 1
+    }
+
+    [System.Serializable]
+    public class VTSInjectParameterData : VTSMessageData {
         public VTSInjectParameterData(){
             this.messageType = "InjectParameterDataRequest";
             this.data = new Data();
@@ -455,12 +481,14 @@ namespace VTS.Models {
 
         [System.Serializable]
         public class Data {
+            public string mode;
+            public bool faceFound;
             public VTSParameterInjectionValue[] parameterValues;
         }
     }
 
     [System.Serializable]
-    public class ExpressionData{
+    public class ExpressionData {
         public string name;
 		public string file;
 		public bool active;
@@ -472,7 +500,7 @@ namespace VTS.Models {
     }
 
     [System.Serializable]
-    public class VTSExpressionStateData : VTSMessageData{
+    public class VTSExpressionStateData : VTSMessageData {
         public VTSExpressionStateData(){
             this.messageType = "ExpressionStateRequest";
             this.data = new Data();
@@ -492,7 +520,7 @@ namespace VTS.Models {
     }
 
     [System.Serializable]
-    public class VTSExpressionActivationData : VTSMessageData{
+    public class VTSExpressionActivationData : VTSMessageData {
         public VTSExpressionActivationData(){
             this.messageType = "ExpressionActivationRequest";
             this.data = new Data();
@@ -506,9 +534,65 @@ namespace VTS.Models {
         }
     }
 
+    [System.Serializable]
+    public class VTSCurrentModelPhysicsData : VTSMessageData {
+        public VTSCurrentModelPhysicsData(){
+            this.messageType = "GetCurrentModelPhysicsRequest";
+            this.data = new Data();
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data {
+            public bool modelLoaded;
+		    public string modelName;
+		    public string modelID;
+		    public bool modelHasPhysics;
+		    public bool physicsSwitchedOn;
+		    public bool usingLegacyPhysics;
+		    public int physicsFPSSetting;
+		    public int baseStrength;
+		    public int baseWind;
+		    public bool apiPhysicsOverrideActive;
+		    public string apiPhysicsOverridePluginNam;
+		    public VTSPhysicsGroup[] physicsGroups;
+        }
+    }
 
     [System.Serializable]
-    public class VTSNDIConfigData : VTSMessageData{
+    public class VTSOverrideModelPhysicsData : VTSMessageData {
+        public VTSOverrideModelPhysicsData(){
+            this.messageType = "SetCurrentModelPhysicsRequest";
+            this.data = new Data();
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data {
+            public VTSPhysicsOverride[] strengthOverrides;
+            public VTSPhysicsOverride[] windOverrides;
+        }
+    }
+
+    [System.Serializable]
+    public class VTSPhysicsGroup {
+        public string groupID;
+		public string groupName;
+		public float strengthMultiplier;
+	    public float windMultiplier;
+    }
+
+    [System.Serializable]
+    public class VTSPhysicsOverride {
+        public string id;
+		public float value;
+		public bool setBaseValue;
+		public float overrideSeconds;
+    }
+
+
+    [System.Serializable]
+    public class VTSNDIConfigData : VTSMessageData {
         public VTSNDIConfigData(){
             this.messageType = "NDIConfigRequest";
             this.data = new Data();
@@ -528,7 +612,7 @@ namespace VTS.Models {
     }
 
     [System.Serializable]
-    public class VTSStateBroadcastData : VTSMessageData{
+    public class VTSStateBroadcastData : VTSMessageData {
         public VTSStateBroadcastData(){
             this.messageType = "VTubeStudioAPIStateBroadcast";
             this.data = new Data();
@@ -543,5 +627,1069 @@ namespace VTS.Models {
             public string windowTitle;
         }
     }
-}
 
+    /// <summary>
+    /// A container for holding the numerous retrieval options for an Item List request.
+    /// 
+    /// For more info about what each field does, see 
+    /// <a href="https://github.com/DenchiSoft/VTubeStudio#requesting-list-of-available-items-or-items-in-scene">https://github.com/DenchiSoft/VTubeStudio#requesting-list-of-available-items-or-items-in-scene</a>
+    /// </summary>
+    [System.Serializable]
+    public class VTSItemListOptions {
+        public VTSItemListOptions(){
+            this.includeAvailableSpots = false;
+            this.includeItemInstancesInScene = false;
+            this.includeAvailableItemFiles = false;
+            this.onlyItemsWithFileName = string.Empty;
+            this.onlyItemsWithInstanceID = string.Empty;
+        }
+
+        public VTSItemListOptions(
+            bool includeAvailableSpots,
+            bool includeItemInstancesInScene,
+            bool includeAvailableItemFiles,
+            string onlyItemsWithFileName,
+            string onlyItemsWithInstanceID
+        ){
+            this.includeAvailableSpots = includeAvailableSpots;
+            this.includeItemInstancesInScene = includeItemInstancesInScene;
+            this.includeAvailableItemFiles = includeAvailableItemFiles;
+            this.onlyItemsWithFileName = onlyItemsWithFileName;
+            this.onlyItemsWithInstanceID = onlyItemsWithInstanceID;
+        }
+
+        public bool includeAvailableSpots;
+        public bool includeItemInstancesInScene;
+        public bool includeAvailableItemFiles;
+        public string onlyItemsWithFileName;
+        public string onlyItemsWithInstanceID;
+    }
+
+    [System.Serializable]
+    public class ItemInstance {
+        public string fileName;
+        public string instanceID;
+        public int order;
+        public string type;
+        public bool censored;
+        public bool flipped;
+        public bool locked;
+        public float smoothing;
+        public float framerate;
+        public int frameCount;
+        public int currentFrame;
+        public bool pinnedToModel;
+        public string pinnedModelID;
+        public string pinnedArtMeshID;
+        public string groupName;
+        public string sceneName;
+        public bool fromWorkshop;
+    }
+
+    [System.Serializable]
+    public class ItemFile {
+        public string fileName;
+        public string type;
+        public int loadedCount;
+    }
+
+    [System.Serializable]
+    public class VTSItemListRequestData : VTSMessageData {
+        public VTSItemListRequestData(){
+            this.messageType = "ItemListRequest";
+            this.data = new Data();
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data {
+            public bool includeAvailableSpots;
+            public bool includeItemInstancesInScene;
+            public bool includeAvailableItemFiles;
+            public string onlyItemsWithFileName;
+            public string onlyItemsWithInstanceID;
+        }
+    }
+
+    [System.Serializable]
+    public class VTSItemListResponseData : VTSMessageData {
+        public VTSItemListResponseData(){
+            this.messageType = "ItemListResponse";
+            this.data = new Data();
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data {
+            public int itemsInSceneCount;
+            public int totalItemsAllowedCount;
+            public bool canLoadItemsRightNow;
+            public int[] availableSpots;
+            public ItemInstance[] itemInstancesInScene;
+            public ItemFile[] availableItemFiles;
+        }
+    }
+
+    /// <summary>
+    /// A container for holding the numerous loading options for an Item Load request.
+    /// 
+    /// For more info about what each field does, see 
+    /// <a href="https://github.com/DenchiSoft/VTubeStudio#loading-item-into-the-scene">https://github.com/DenchiSoft/VTubeStudio#loading-item-into-the-scene</a>
+    /// </summary>
+    [System.Serializable]
+    public class VTSItemLoadOptions {
+        public VTSItemLoadOptions(){
+            this.positionX = 0;
+            this.positionY = 0;
+            this.size = 0.32f;
+            this.rotation = 0f;
+            this.fadeTime = 0;
+            this.order = 1;
+            this.failIfOrderTaken = false;
+            this.smoothing = 0f;
+            this.censored = false;
+            this.flipped = false;
+            this.locked = false;
+            this.unloadWhenPluginDisconnects = true;
+        }
+
+        public VTSItemLoadOptions(
+            float positionX,
+            float positionY,
+            float size,
+            float rotation,
+            float fadeTime,
+            int order,
+            bool failIfOrderTaken,
+            float smoothing,
+            bool censored,
+            bool flipped,
+            bool locked,
+            bool unloadWhenPluginDisconnects
+        ){
+            this.positionX = positionX;
+            this.positionY = positionY;
+            this.size = size;
+            this.rotation = rotation;
+            this.fadeTime = fadeTime;
+            this.order = order;
+            this.failIfOrderTaken = failIfOrderTaken;
+            this.smoothing = smoothing;
+            this.censored = censored;
+            this.flipped = flipped;
+            this.locked = locked;
+            this.unloadWhenPluginDisconnects = unloadWhenPluginDisconnects;
+        }
+
+        public float positionX;
+        public float positionY;
+        public float size;
+        public float rotation;
+        public float fadeTime;
+        public int order;
+        public bool failIfOrderTaken;
+        public float smoothing;
+        public bool censored;
+        public bool flipped;
+        public bool locked;
+        public bool unloadWhenPluginDisconnects;
+    }
+
+    [System.Serializable]
+    public class VTSItemLoadRequestData : VTSMessageData {
+        public VTSItemLoadRequestData(){
+            this.messageType = "ItemLoadRequest";
+            this.data = new Data();
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data {
+            public string fileName;
+		    public float positionX;
+		    public float positionY;
+		    public float size;
+		    public float rotation;
+		    public float fadeTime;
+		    public int order;
+		    public bool failIfOrderTaken;
+		    public float smoothing;
+		    public bool censored;
+		    public bool flipped;
+		    public bool locked;
+		    public bool unloadWhenPluginDisconnects;
+        }
+    }
+
+    [System.Serializable]
+    public class VTSItemLoadResponseData : VTSMessageData {
+        public VTSItemLoadResponseData(){
+            this.messageType = "ItemLoadResponse";
+            this.data = new Data();
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data {
+            public string instanceID;
+        }
+    }
+
+    /// <summary>
+    /// A container for holding the numerous unloading options for an Item Unload request.
+    /// 
+    /// For more info about what each field does, see 
+    /// <a href="https://github.com/DenchiSoft/VTubeStudio#removing-item-from-the-scene">https://github.com/DenchiSoft/VTubeStudio#removing-item-from-the-scene</a>
+    /// </summary>
+    [System.Serializable]
+    public class VTSItemUnloadOptions {
+        public VTSItemUnloadOptions(){
+            this.itemInstanceIDs = new string[0];
+            this.fileNames = new string[0];
+            this.unloadAllInScene = false;
+            this.unloadAllLoadedByThisPlugin = false;
+            this.allowUnloadingItemsLoadedByUserOrOtherPlugins = false;
+        }
+
+        public VTSItemUnloadOptions(
+            string[] itemInstanceIDs,
+            string[] fileNames,
+            bool unloadAllInScene,
+            bool unloadAllLoadedByThisPlugin,
+            bool allowUnloadingItemsLoadedByUserOrOtherPlugins
+        ){
+            this.itemInstanceIDs = itemInstanceIDs;
+            this.fileNames = fileNames;
+            this.unloadAllInScene = unloadAllInScene;
+            this.unloadAllLoadedByThisPlugin = unloadAllLoadedByThisPlugin;
+            this.allowUnloadingItemsLoadedByUserOrOtherPlugins = allowUnloadingItemsLoadedByUserOrOtherPlugins;
+        }
+
+        public string[] itemInstanceIDs;
+        public string[] fileNames;
+        public bool unloadAllInScene;
+        public bool unloadAllLoadedByThisPlugin;
+        public bool allowUnloadingItemsLoadedByUserOrOtherPlugins;
+    }
+
+    [System.Serializable]
+    public class UnloadedItem { 
+        public string instanceID;
+        public string fileName;
+    }
+
+    [System.Serializable]
+    public class VTSItemUnloadRequestData : VTSMessageData {
+        public VTSItemUnloadRequestData(){
+            this.messageType = "ItemUnloadRequest";
+            this.data = new Data();
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data {
+            public bool unloadAllInScene;
+            public bool unloadAllLoadedByThisPlugin;
+            public bool allowUnloadingItemsLoadedByUserOrOtherPlugins;
+            public string[] instanceIDs;
+            public string[] fileNames; 
+        }
+    }
+
+    [System.Serializable]
+    public class VTSItemUnloadResponseData : VTSMessageData {
+        public VTSItemUnloadResponseData(){
+            this.messageType = "ItemUnloadResponse";
+            this.data = new Data();
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data {
+            public UnloadedItem[] unloadedItems;
+        }
+    }
+
+    /// <summary>
+    /// A container for holding the numerous animation options for an Item Animation Control request.
+    /// 
+    /// For more info about what each field does, see 
+    /// <a href="https://github.com/DenchiSoft/VTubeStudio#controling-items-and-item-animations">https://github.com/DenchiSoft/VTubeStudio#controling-items-and-item-animations</a>
+    /// </summary>
+    [System.Serializable]
+    public class VTSItemAnimationControlOptions {
+        public VTSItemAnimationControlOptions(){
+            this.framerate = -1;
+            this.frame = -1;
+            this.brightness = -1;
+            this.opacity = -1;
+            this.setAutoStopFrames = false;
+            this.autoStopFrames = new int[0];
+            this.setAnimationPlayState = false;
+            this.animationPlayState = false;
+        }
+
+        public VTSItemAnimationControlOptions(
+            int framerate,
+            int frame,
+            float brightness,
+            float opacity,
+            bool setAutoStopFrames,
+            int[] autoStopFrames,
+            bool setAnimationPlayState,
+            bool animationPlayState
+        ){
+            this.framerate = framerate;
+            this.frame = frame;
+            this.brightness = brightness;
+            this.opacity = opacity;
+            this.setAutoStopFrames = setAutoStopFrames;
+            this.autoStopFrames = autoStopFrames;
+            this.setAnimationPlayState = setAnimationPlayState;
+            this.animationPlayState = animationPlayState;
+        }
+
+        public int framerate;
+        public int frame;
+        public float brightness;
+        public float opacity;
+        public bool setAutoStopFrames;
+        public int[] autoStopFrames;
+        public bool setAnimationPlayState;
+        public bool animationPlayState;
+    }
+
+    [System.Serializable]
+    public class VTSItemAnimationControlRequestData : VTSMessageData {
+        public VTSItemAnimationControlRequestData(){
+            this.messageType = "ItemAnimationControlRequest";
+            this.data = new Data();
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data {
+            public string itemInstanceID;
+            public int framerate;
+            public int frame;
+            public float brightness;
+            public float opacity;
+            public bool setAutoStopFrames;
+            public int[] autoStopFrames;
+            public bool setAnimationPlayState;
+            public bool animationPlayState;
+        }
+    }
+
+    [System.Serializable]
+    public class VTSItemAnimationControlResponseData : VTSMessageData {
+        public VTSItemAnimationControlResponseData(){
+            this.messageType = "ItemAnimationControlResponse";
+            this.data = new Data();
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data {
+            public int frame;
+            public bool animationPlaying;
+        }
+    }
+
+    [System.Serializable]
+    public enum VTSItemMotionCurve : int {
+        UNKNOW = -1,
+        LINEAR = 0,
+        EASE_IN = 1,
+        EASE_OUT = 2,
+        EASE_BOTH = 3,
+        OVERSHOOT = 4,
+        ZIP = 5
+    }
+
+    /// <summary>
+    /// A container for holding the numerous movement options for an Item Move request.
+    /// 
+    /// For more info about what each field does, see 
+    /// <a href="https://github.com/DenchiSoft/VTubeStudio#moving-items-in-the-scene">https://github.com/DenchiSoft/VTubeStudio#moving-items-in-the-scene</a>
+    /// </summary>
+    [System.Serializable]
+    public class VTSItemMoveOptions {
+        public VTSItemMoveOptions(){
+            this.timeInSeconds = 0f;
+            this.fadeMode = VTSItemMotionCurve.LINEAR;
+            this.positionX = -1000;
+            this.positionY = -1000;
+            this.size = -1000;
+            this.rotation = -1000;
+            this.order = -1000;
+            this.setFlip = false;
+            this.flip = false;
+            this.userCanStop = false;
+        }
+
+        public VTSItemMoveOptions(
+            float timeInSeconds,
+            VTSItemMotionCurve fadeMode,
+            float positionX,
+            float positionY,
+            float size,
+            float rotation,
+            int order,
+            bool setFlip,
+            bool flip,
+            bool userCanStop
+        ){
+            this.timeInSeconds = timeInSeconds;
+            this.fadeMode = fadeMode;
+            this.positionX = positionX;
+            this.positionY = positionY;
+            this.size = size;
+            this.rotation = rotation;
+            this.order = order;
+            this.setFlip = setFlip;
+            this.flip = flip;
+            this.userCanStop = userCanStop;
+        }
+        
+        public float timeInSeconds;
+        public VTSItemMotionCurve fadeMode;
+        public float positionX;
+        public float positionY;
+        public int order;
+        public float size;
+        public float rotation;
+        public bool setFlip;
+        public bool flip;
+        public bool userCanStop;
+    }
+
+    /// <summary>
+    /// A container for linking an Item Instance ID to its corresponding options for an Item Move request.
+    /// 
+    /// For more info about what each field does, see 
+    /// <a href="https://github.com/DenchiSoft/VTubeStudio#moving-items-in-the-scene">https://github.com/DenchiSoft/VTubeStudio#moving-items-in-the-scene</a>
+    /// </summary>
+    [System.Serializable]
+    public struct VTSItemMoveEntry {
+        public VTSItemMoveEntry(string itemInsanceID, VTSItemMoveOptions options){
+            this.itemInsanceID = itemInsanceID;
+            this.options = options;
+        }
+        
+        public string itemInsanceID;
+        public VTSItemMoveOptions options;
+    }
+
+    [System.Serializable]
+    public struct VTSItemToMove {
+        public VTSItemToMove(
+            string itemInstanceID,
+            float timeInSeconds,
+            string fadeMode,
+            float positionX,
+            float positionY,
+            float size,
+            float rotation,
+            int order,
+            bool setFlip,
+            bool flip,
+            bool userCanStop
+        ){
+            this.itemInstanceID = itemInstanceID;
+            this.timeInSeconds = timeInSeconds;
+            this.fadeMode = fadeMode;
+            this.positionX = positionX;
+            this.positionY = positionY;
+            this.size = size;
+            this.rotation = rotation;
+            this.order = order;
+            this.setFlip = setFlip;
+            this.flip = flip;
+            this.userCanStop = userCanStop;
+        }
+
+        public string itemInstanceID;
+        public float timeInSeconds;
+        public string fadeMode;
+        public float positionX;
+        public float positionY;
+        public int order;
+        public float size;
+        public float rotation;
+        public bool setFlip;
+        public bool flip;
+        public bool userCanStop;
+    }
+
+    [System.Serializable]
+    public class VTSItemMoveRequestData : VTSMessageData {
+        public VTSItemMoveRequestData(){
+            this.messageType = "ItemMoveRequest";
+            this.data = new Data();
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data {
+            public VTSItemToMove[] itemsToMove;
+        }
+    }
+
+    [System.Serializable]
+    public struct MovedItem {
+        public string itemInstanceID;
+        public bool success;
+        public ErrorID errorID;
+    }
+
+    [System.Serializable]
+    public class VTSItemMoveResponseData : VTSMessageData {
+        public VTSItemMoveResponseData(){
+            this.messageType = "ItemMoveResponse";
+            this.data = new Data();
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data {
+            public MovedItem[] movedItems;
+        }
+    }
+
+    [System.Serializable]
+    public class VTSArtMeshSelectionRequestData : VTSMessageData {
+        public VTSArtMeshSelectionRequestData(){
+            this.messageType = "ArtMeshSelectionRequest";
+            this.data = new Data();
+
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data {
+            public string textOverride;
+            public string helpOverride;
+            public int requestedArtMeshCount;
+            public string[] activeArtMeshes;
+
+        }
+    }
+
+    [System.Serializable]
+    public class VTSArtMeshSelectionResponseData : VTSMessageData {
+        public VTSArtMeshSelectionResponseData(){
+            this.messageType = "ArtMeshSelectionResponse";
+            this.data = new Data();
+
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data {
+
+            public bool success;
+            public string[] activeArtMeshes;
+            public string[] inactiveArtMeshes;
+        }
+    }
+
+    #endregion
+
+    #region Event API
+
+    [System.Serializable]
+    public abstract class VTSEventSubscriptionRequestData : VTSMessageData { 
+        public abstract void SetEventName(string eventName);
+        public abstract string GetEventName();
+        public abstract void SetSubscribed(bool subscribe);
+        public abstract bool GetSubscribed();
+        public abstract void SetConfig(VTSEventConfigData config);
+    }
+
+    [System.Serializable]
+    public abstract class VTSEventSubscriptonData {
+        public string eventName;
+        public bool subscribe;
+    }
+
+    [System.Serializable]
+    public abstract class VTSEventConfigData { }
+
+    [System.Serializable]
+    public abstract class VTSEventData : VTSMessageData { }
+
+    [System.Serializable]
+    public class VTSEventSubscriptionResponseData : VTSMessageData {
+        public VTSEventSubscriptionResponseData(){
+            this.messageType = "EventSubscriptionResponse";
+            this.data = new Data();
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data {
+            public int subscribedEventCount;
+            public string[] subscribedEvents;
+        }
+    }
+
+    // Test Event
+
+    [System.Serializable]
+    public class VTSTestEventSubscriptionRequestData : VTSEventSubscriptionRequestData {
+        public VTSTestEventSubscriptionRequestData(){
+            this.messageType = "EventSubscriptionRequest";
+            this.data = new Data();
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data : VTSEventSubscriptonData {
+            public VTSTestEventConfigOptions config;
+        }
+
+        public override void SetEventName(string eventName) {
+            this.data.eventName = eventName;
+        }
+
+        public override string GetEventName(){
+            return this.data.eventName;
+        }
+
+        public override void SetSubscribed(bool subscribe) {
+            this.data.subscribe = subscribe;
+        }
+
+        public override bool GetSubscribed(){
+            return this.data.subscribe;
+        }
+
+        public override void SetConfig(VTSEventConfigData config){
+            this.data.config = (VTSTestEventConfigOptions)config;
+        }
+    }
+
+    /// <summary>
+    /// A container for providing subscription options for a Test Event subscription.
+    /// 
+    /// For more info about what each field does, see 
+    /// <a href="https://github.com/DenchiSoft/VTubeStudio/blob/master/Events/README.md#test-event">https://github.com/DenchiSoft/VTubeStudio/blob/master/Events/README.md#test-event</a>
+    /// </summary>
+    [System.Serializable]
+    public class VTSTestEventConfigOptions : VTSEventConfigData {
+        public VTSTestEventConfigOptions(){
+            this.testMessageForEvent = null;
+        }
+        
+        public VTSTestEventConfigOptions(string message){
+            this.testMessageForEvent = message;
+        }
+        public string testMessageForEvent;
+    }
+
+    [System.Serializable]
+    public class VTSTestEventData : VTSEventData {
+        public VTSTestEventData(){
+            this.messageType = "TestEvent";
+            this.data = new Data();
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data {
+            public string yourTestMessage;
+            public long counter;
+        }
+    }
+
+    // Model Loaded Event
+
+    [System.Serializable]
+    public class VTSModelLoadedEventSubscriptionRequestData : VTSEventSubscriptionRequestData {
+        public VTSModelLoadedEventSubscriptionRequestData(){
+            this.messageType = "EventSubscriptionRequest";
+            this.data = new Data();
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data : VTSEventSubscriptonData {
+            public VTSModelLoadedEventConfigOptions config;
+        }
+
+        public override void SetEventName(string eventName){
+            this.data.eventName = "ModelLoadedEvent";
+        }
+
+        public override string GetEventName(){
+            return this.data.eventName;
+        }
+
+        public override void SetSubscribed(bool subscribe){
+            this.data.subscribe = subscribe;
+        }
+
+        public override bool GetSubscribed(){
+            return this.data.subscribe;
+        }
+
+        public override void SetConfig(VTSEventConfigData config){
+            this.data.config = (VTSModelLoadedEventConfigOptions)config;
+        }
+    }
+
+    /// <summary>
+    /// A container for providing subscription options for a Model Loaded Event subscription.
+    /// 
+    /// For more info about what each field does, see 
+    /// <a href="https://github.com/DenchiSoft/VTubeStudio/blob/master/Events/README.md#model-loadedunloaded">https://github.com/DenchiSoft/VTubeStudio/blob/master/Events/README.md#model-loadedunloaded</a>
+    /// </summary>
+    [System.Serializable]
+    public class VTSModelLoadedEventConfigOptions : VTSEventConfigData {
+        public VTSModelLoadedEventConfigOptions(){
+            this.modelID = null;
+        }
+        public VTSModelLoadedEventConfigOptions(string modelID){
+            this.modelID = modelID;
+        }
+        public string modelID;
+    }
+
+    [System.Serializable]
+    public class VTSModelLoadedEventData : VTSEventData {
+        public VTSModelLoadedEventData(){
+            this.messageType = "ModelLoadedEvent";
+            this.data = new Data();
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data : ModelData { }
+    }
+    
+    // Tracking Changed Event
+
+    [System.Serializable]
+    public class VTSTrackingEventSubscriptionRequestData : VTSEventSubscriptionRequestData {
+        public VTSTrackingEventSubscriptionRequestData(){
+            this.messageType = "EventSubscriptionRequest";
+            this.data = new Data();
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data : VTSEventSubscriptonData {
+            public VTSTrackingEventConfigOptions config;
+        }
+
+        public override void SetEventName(string eventName) {
+            this.data.eventName = eventName;
+        }
+
+        public override string GetEventName(){
+            return this.data.eventName;
+        }
+
+        public override void SetSubscribed(bool subscribe) {
+            this.data.subscribe = subscribe;
+        }
+
+        public override bool GetSubscribed(){
+            return this.data.subscribe;
+        }
+
+        public override void SetConfig(VTSEventConfigData config){
+            this.data.config = (VTSTrackingEventConfigOptions)config;
+        }
+    }
+
+    /// <summary>
+    /// A container for providing subscription options for a Lost Tracking Event subscription.
+    /// 
+    /// For more info about what each field does, see 
+    /// <a href="https://github.com/DenchiSoft/VTubeStudio/blob/master/Events/README.md#lostfound-tracking">https://github.com/DenchiSoft/VTubeStudio/blob/master/Events/README.md#lostfound-tracking</a>
+    /// </summary>
+    [System.Serializable]
+    public class VTSTrackingEventConfigOptions : VTSEventConfigData {
+        public VTSTrackingEventConfigOptions(){ }
+    }
+
+    [System.Serializable]
+    public class VTSTrackingEventData : VTSEventData {
+        public VTSTrackingEventData(){
+            this.messageType = "TrackingStatusChangedEvent";
+            this.data = new Data();
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data {
+            public bool faceFound;
+            public bool leftHandFound;
+            public bool rightHandFound;
+        }
+    }
+
+    // Background Changed Event
+
+    [System.Serializable]
+    public class VTSBackgroundChangedEventSubscriptionRequestData : VTSEventSubscriptionRequestData {
+        public VTSBackgroundChangedEventSubscriptionRequestData(){
+            this.messageType = "EventSubscriptionRequest";
+            this.data = new Data();
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data : VTSEventSubscriptonData {
+            public VTSBackgroundChangedEventConfigOptions config;
+        }
+
+        public override void SetEventName(string eventName) {
+            this.data.eventName = eventName;
+        }
+
+        public override string GetEventName(){
+            return this.data.eventName;
+        }
+
+        public override void SetSubscribed(bool subscribe) {
+            this.data.subscribe = subscribe;
+        }
+
+        public override bool GetSubscribed(){
+            return this.data.subscribe;
+        }
+
+        public override void SetConfig(VTSEventConfigData config){
+            this.data.config = (VTSBackgroundChangedEventConfigOptions)config;
+        }
+    }
+
+    /// <summary>
+    /// A container for providing subscription options for a Background Changed Event subscription.
+    /// 
+    /// For more info about what each field does, see 
+    /// <a href="https://github.com/DenchiSoft/VTubeStudio/blob/master/Events/README.md#background-changed">https://github.com/DenchiSoft/VTubeStudio/blob/master/Events/README.md#background-changed</a>
+    /// </summary>
+    [System.Serializable]
+    public class VTSBackgroundChangedEventConfigOptions : VTSEventConfigData {
+        public VTSBackgroundChangedEventConfigOptions(){ }
+    }
+
+    [System.Serializable]
+    public class VTSBackgroundChangedEventData : VTSEventData {
+        public VTSBackgroundChangedEventData(){
+            this.messageType = "BackgroundChangedEvent";
+            this.data = new Data();
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data {
+            public string backgroundName;
+        }
+    }
+
+    // Model Config Changed Event
+
+    [System.Serializable]
+    public class VTSModelConfigChangedEventSubscriptionRequestData : VTSEventSubscriptionRequestData {
+        public VTSModelConfigChangedEventSubscriptionRequestData(){
+            this.messageType = "EventSubscriptionRequest";
+            this.data = new Data();
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data : VTSEventSubscriptonData {
+            public VTSModelConfigChangedEventConfigOptions config;
+        }
+
+        public override void SetEventName(string eventName) {
+            this.data.eventName = eventName;
+        }
+
+        public override string GetEventName(){
+            return this.data.eventName;
+        }
+
+        public override void SetSubscribed(bool subscribe) {
+            this.data.subscribe = subscribe;
+        }
+
+        public override bool GetSubscribed(){
+            return this.data.subscribe;
+        }
+
+        public override void SetConfig(VTSEventConfigData config){
+            this.data.config = (VTSModelConfigChangedEventConfigOptions)config;
+        }
+    }
+
+    /// <summary>
+    /// A container for providing subscription options for a Model Config Changed Event subscription.
+    /// 
+    /// For more info about what each field does, see 
+    /// <a href="https://github.com/DenchiSoft/VTubeStudio/blob/master/Events/README.md#model-config-modified">https://github.com/DenchiSoft/VTubeStudio/blob/master/Events/README.md#model-config-modified</a>
+    /// </summary>
+    [System.Serializable]
+    public class VTSModelConfigChangedEventConfigOptions : VTSEventConfigData {
+        public VTSModelConfigChangedEventConfigOptions(){ }
+    }
+
+    [System.Serializable]
+    public class VTSModelConfigChangedEventData : VTSEventData {
+        public VTSModelConfigChangedEventData(){
+            this.messageType = "ModelConfigChangedEvent";
+            this.data = new Data();
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data {
+            public string modelID;
+            public string modelName;
+            public bool hotkeyConfigChanged;
+        }
+    }
+
+    // Model Moved Event
+
+    [System.Serializable]
+    public class VTSModelMovedEventSubscriptionRequestData : VTSEventSubscriptionRequestData {
+        public VTSModelMovedEventSubscriptionRequestData(){
+            this.messageType = "EventSubscriptionRequest";
+            this.data = new Data();
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data : VTSEventSubscriptonData {
+            public VTSModelMovedEventConfigOptions config;
+        }
+
+        public override void SetEventName(string eventName) {
+            this.data.eventName = eventName;
+        }
+
+        public override string GetEventName(){
+            return this.data.eventName;
+        }
+
+        public override void SetSubscribed(bool subscribe) {
+            this.data.subscribe = subscribe;
+        }
+
+        public override bool GetSubscribed(){
+            return this.data.subscribe;
+        }
+
+        public override void SetConfig(VTSEventConfigData config){
+            this.data.config = (VTSModelMovedEventConfigOptions)config;
+        }
+    }
+
+    /// <summary>
+    /// A container for providing subscription options for a Model Config Changed Event subscription.
+    /// 
+    /// For more info about what each field does, see 
+    /// <a href="https://github.com/DenchiSoft/VTubeStudio/blob/master/Events/README.md#model-movedresizedrotated">https://github.com/DenchiSoft/VTubeStudio/blob/master/Events/README.md#model-movedresizedrotated</a>
+    /// </summary>
+    [System.Serializable]
+    public class VTSModelMovedEventConfigOptions : VTSEventConfigData {
+        public VTSModelMovedEventConfigOptions(){ }
+    }
+
+    [System.Serializable]
+    public class VTSModelMovedEventData : VTSEventData {
+        public VTSModelMovedEventData(){
+            this.messageType = "ModelMovedEvent";
+            this.data = new Data();
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data {
+            public string modelID;
+            public string modelName;
+            public ModelPosition modelPosition;
+        }
+    }
+
+    // Model Outline Event
+
+    [System.Serializable]
+    public class VTSModelOutlineEventSubscriptionRequestData : VTSEventSubscriptionRequestData {
+        public VTSModelOutlineEventSubscriptionRequestData(){
+            this.messageType = "EventSubscriptionRequest";
+            this.data = new Data();
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data : VTSEventSubscriptonData {
+            public VTSModelOutlineEventConfigOptions config;
+        }
+
+        public override void SetEventName(string eventName) {
+            this.data.eventName = eventName;
+        }
+
+        public override string GetEventName(){
+            return this.data.eventName;
+        }
+
+        public override void SetSubscribed(bool subscribe) {
+            this.data.subscribe = subscribe;
+        }
+
+        public override bool GetSubscribed(){
+            return this.data.subscribe;
+        }
+
+        public override void SetConfig(VTSEventConfigData config){
+            this.data.config = (VTSModelOutlineEventConfigOptions)config;
+        }
+    }
+
+    /// <summary>
+    /// A container for providing subscription options for a Model Outline Event subscription.
+    /// 
+    /// For more info about what each field does, see 
+    /// <a href="https://github.com/DenchiSoft/VTubeStudio/blob/master/Events/README.md#model-outline-changed">https://github.com/DenchiSoft/VTubeStudio/blob/master/Events/README.md#model-outline-changed</a>
+    /// </summary>
+    [System.Serializable]
+    public class VTSModelOutlineEventConfigOptions : VTSEventConfigData {
+        public VTSModelOutlineEventConfigOptions(){ 
+            this.draw = false;
+        }
+
+        public VTSModelOutlineEventConfigOptions(bool draw){ 
+            this.draw = draw;
+        }
+
+        public bool draw = false;
+    }
+
+    [System.Serializable]
+    public class VTSModelOutlineEventData : VTSEventData {
+        public VTSModelOutlineEventData(){
+            this.messageType = "ModelOutlineEvent";
+            this.data = new Data();
+        }
+        public Data data;
+
+        [System.Serializable]
+        public class Data {
+            public string modelID;
+            public string modelName;
+            public Pair[] convexHull;
+            public Pair convexHullCenter;
+            public Pair windowSize;
+        }
+    }
+
+    #endregion
+}

--- a/Assets/Core/VTS/Networking/VTSWebSocket.cs
+++ b/Assets/Core/VTS/Networking/VTSWebSocket.cs
@@ -31,7 +31,18 @@ namespace VTS.Networking {
         private static Task<UdpReceiveResult> UDP_RESULT = null;
         private static readonly Dictionary<int, VTSStateBroadcastData> PORTS = new Dictionary<int, VTSStateBroadcastData>();
 
+        public delegate void PortDiscoveryEvent(VTSStateBroadcastData portData);
+        public static event PortDiscoveryEvent OnPortDiscovered;
+
         #region Lifecycle
+
+        /*
+        TODO: make a static event that executes every time the list of ports updates, with the new port
+        Then, in the plugin Initialize method, don't attempt connection/auth until we get the first execution of this event.
+        Correct to the first port you find.
+
+        We should also use the this.Socket accessor internally, and have that do the getComponent<...>() call so we have the socket when we need it.
+        */
 
         public void Initialize(IWebSocket webSocket, IJsonUtility jsonUtility){
             if(this._ws != null){
@@ -75,6 +86,7 @@ namespace VTS.Networking {
                             PORTS.Remove(data.data.port);
                         }
                         PORTS.Add(data.data.port, data);
+                        OnPortDiscovered.Invoke(data);
                         // if(!PORTS.ContainsKey(this._port) && PORTS.Count == 1){
                         //     onPortChange(data.data.port);
                         // }

--- a/Assets/Core/VTS/Networking/VTSWebSocket.cs
+++ b/Assets/Core/VTS/Networking/VTSWebSocket.cs
@@ -10,18 +10,27 @@ using UnityEngine;
 using VTS.Models;
 
 namespace VTS.Networking {
+    /// <summary>
+    /// Underlying VTS socket connection and response processor.
+    /// </summary>
     public class VTSWebSocket : MonoBehaviour
     {
+        // Dependencies
         private const string VTS_WS_URL = "ws://localhost:{0}";
         private int _port = 8001;
         private IWebSocket _ws = null;
         private IJsonUtility _json = null;
+
+        // API Callbacks
         private Dictionary<string, VTSCallbacks> _callbacks = new Dictionary<string, VTSCallbacks>();
+        private Dictionary<string, VTSEventCallbacks> _events = new Dictionary<string, VTSEventCallbacks>();
 
         // UDP 
         private static UdpClient UDP_CLIENT = null;
         private static Task<UdpReceiveResult> UDP_RESULT = null;
         private static readonly Dictionary<int, VTSStateBroadcastData> PORTS = new Dictionary<int, VTSStateBroadcastData>();
+
+        #region Lifecycle
 
         public void Initialize(IWebSocket webSocket, IJsonUtility jsonUtility){
             if(this._ws != null){
@@ -40,6 +49,10 @@ namespace VTS.Networking {
             ProcessResponses();
             CheckPorts();
         }
+
+        #endregion
+
+        #region UDP
 
         private void CheckPorts(){
             StartUDP();
@@ -81,6 +94,22 @@ namespace VTS.Networking {
                 Debug.LogError(e);
             }
         }
+        
+        public Dictionary<int, VTSStateBroadcastData> GetPorts(){
+            return new Dictionary<int, VTSStateBroadcastData>(PORTS);
+        }
+
+        public bool SetPort(int port){
+            if(PORTS.ContainsKey(port)){
+                this._port = port;
+                return true;
+            }
+            return false;
+        }
+
+        #endregion
+
+        #region I/O
 
         private void ProcessResponses(){
             string data = null;
@@ -88,82 +117,142 @@ namespace VTS.Networking {
                 if(this._ws != null){
                     data = this._ws.GetNextResponse();
                     if(data != null){
-                        VTSMessageData response = _json.FromJson<VTSMessageData>(data);
-                        if(this._callbacks.ContainsKey(response.requestID)){
+                        VTSMessageData response = this._json.FromJson<VTSMessageData>(data);
+                        if(this._events.ContainsKey(response.messageType)){
+                            try{
+                                switch(response.messageType){
+                                    case "TestEvent":
+                                        this._events[response.messageType].onEvent(this._json.FromJson<VTSTestEventData>(data));
+                                        break;
+                                    case "ModelLoadedEvent":
+                                        this._events[response.messageType].onEvent(this._json.FromJson<VTSModelLoadedEventData>(data));
+                                        break;
+                                    case "TrackingStatusChangedEvent":
+                                        this._events[response.messageType].onEvent(this._json.FromJson<VTSTrackingEventData>(data));
+                                        break;
+                                    case "BackgroundChangedEvent":
+                                        this._events[response.messageType].onEvent(this._json.FromJson<VTSBackgroundChangedEventData>(data));
+                                        break;
+                                    case "ModelConfigChangedEvent":
+                                        this._events[response.messageType].onEvent(this._json.FromJson<VTSModelConfigChangedEventData>(data));
+                                        break;
+                                    case "ModelMovedEvent":
+                                        this._events[response.messageType].onEvent(this._json.FromJson<VTSModelMovedEventData>(data));
+                                        break;
+                                    case "ModelOutlineEvent":
+                                        this._events[response.messageType].onEvent(this._json.FromJson<VTSModelOutlineEventData>(data));
+                                        break;
+                                }
+                            }catch(Exception e){
+                                // Neatly handle errors in case the deserialization or success callback throw an exception
+                                VTSErrorData error = new VTSErrorData();
+                                error.requestID = response.requestID;
+                                error.data.message = e.Message;
+                                this._events[response.messageType].onError(error);
+                            }
+                        }
+                        else if(this._callbacks.ContainsKey(response.requestID)){
                             try{
                                 switch(response.messageType){
                                     case "APIError":
-                                        this._callbacks[response.requestID].onError(_json.FromJson<VTSErrorData>(data));
+                                        this._callbacks[response.requestID].onError(this._json.FromJson<VTSErrorData>(data));
                                         break;
                                     case "APIStateResponse":
-                                        this._callbacks[response.requestID].onSuccess(_json.FromJson<VTSStateData>(data));
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSStateData>(data));
                                         break;
                                     case "StatisticsResponse":
-                                        this._callbacks[response.requestID].onSuccess(_json.FromJson<VTSStatisticsData>(data));
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSStatisticsData>(data));
                                         break;
                                     case "AuthenticationResponse":
                                     case "AuthenticationTokenResponse":
-                                        this._callbacks[response.requestID].onSuccess(_json.FromJson<VTSAuthData>(data));
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSAuthData>(data));
                                         break;
                                     case "VTSFolderInfoResponse":
-                                        this._callbacks[response.requestID].onSuccess(_json.FromJson<VTSFolderInfoData>(data));
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSFolderInfoData>(data));
                                         break;
                                     case "CurrentModelResponse":
-                                        this._callbacks[response.requestID].onSuccess(_json.FromJson<VTSCurrentModelData>(data));
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSCurrentModelData>(data));
                                         break;
                                     case "AvailableModelsResponse":
-                                        this._callbacks[response.requestID].onSuccess(_json.FromJson<VTSAvailableModelsData>(data));
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSAvailableModelsData>(data));
                                         break;
                                     case "ModelLoadResponse":
-                                        this._callbacks[response.requestID].onSuccess(_json.FromJson<VTSModelLoadData>(data));
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSModelLoadData>(data));
                                         break;
                                     case "MoveModelResponse":
-                                        this._callbacks[response.requestID].onSuccess(_json.FromJson<VTSMoveModelData>(data));
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSMoveModelData>(data));
                                         break;
                                     case "HotkeysInCurrentModelResponse":
-                                        this._callbacks[response.requestID].onSuccess(_json.FromJson<VTSHotkeysInCurrentModelData>(data));
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSHotkeysInCurrentModelData>(data));
                                         break;
                                     case "HotkeyTriggerResponse":
-                                        this._callbacks[response.requestID].onSuccess(_json.FromJson<VTSHotkeyTriggerData>(data));
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSHotkeyTriggerData>(data));
                                         break;
                                     case "ArtMeshListResponse":
-                                        this._callbacks[response.requestID].onSuccess(_json.FromJson<VTSArtMeshListData>(data));
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSArtMeshListData>(data));
                                         break;
                                     case "ColorTintResponse":
-                                        this._callbacks[response.requestID].onSuccess(_json.FromJson<VTSColorTintData>(data));
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSColorTintData>(data));
                                         break;
                                     case "SceneColorOverlayInfoResponse":
-                                        this._callbacks[response.requestID].onSuccess(_json.FromJson<VTSSceneColorOverlayData>(data));
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSSceneColorOverlayData>(data));
                                         break;
                                     case "FaceFoundResponse":
-                                        this._callbacks[response.requestID].onSuccess(_json.FromJson<VTSFaceFoundData>(data));
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSFaceFoundData>(data));
                                         break;
                                     case "InputParameterListResponse":
-                                        this._callbacks[response.requestID].onSuccess(_json.FromJson<VTSInputParameterListData>(data));
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSInputParameterListData>(data));
                                         break;
                                     case "ParameterValueResponse":
-                                        this._callbacks[response.requestID].onSuccess(_json.FromJson<VTSParameterValueData>(data));
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSParameterValueData>(data));
                                         break;
                                     case "Live2DParameterListResponse":
-                                        this._callbacks[response.requestID].onSuccess(_json.FromJson<VTSLive2DParameterListData>(data));
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSLive2DParameterListData>(data));
                                         break;
                                     case "ParameterCreationResponse":
-                                        this._callbacks[response.requestID].onSuccess(_json.FromJson<VTSParameterCreationData>(data));
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSParameterCreationData>(data));
                                         break;
                                     case "ParameterDeletionResponse":
-                                        this._callbacks[response.requestID].onSuccess(_json.FromJson<VTSParameterDeletionData>(data));
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSParameterDeletionData>(data));
                                         break;
                                     case "InjectParameterDataResponse":
-                                        this._callbacks[response.requestID].onSuccess(_json.FromJson<VTSInjectParameterData>(data));
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSInjectParameterData>(data));
                                         break;
                                     case "ExpressionStateResponse":
-                                        this._callbacks[response.requestID].onSuccess(_json.FromJson<VTSExpressionStateData>(data));
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSExpressionStateData>(data));
                                         break;
                                     case "ExpressionActivationResponse":
-                                        this._callbacks[response.requestID].onSuccess(_json.FromJson<VTSExpressionActivationData>(data));
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSExpressionActivationData>(data));
+                                        break;
+                                    case "GetCurrentModelPhysicsResponse":
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSCurrentModelPhysicsData>(data));
+                                        break;
+                                    case "SetCurrentModelPhysicsResponse":
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSOverrideModelPhysicsData>(data));
                                         break;
                                     case "NDIConfigResponse":
-                                        this._callbacks[response.requestID].onSuccess(_json.FromJson<VTSNDIConfigData>(data));
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSNDIConfigData>(data));
+                                        break;
+                                    case "ItemListResponse":
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSItemListResponseData>(data));
+                                        break;
+                                    case "ItemLoadResponse":
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSItemLoadResponseData>(data));
+                                        break;
+                                    case "ItemUnloadResponse":
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSItemUnloadResponseData>(data));
+                                        break;
+                                    case "ItemAnimationControlResponse":
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSItemAnimationControlResponseData>(data));
+                                        break;
+                                    case "ItemMoveResponse":
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSItemMoveResponseData>(data));
+                                        break;
+                                    case "ArtMeshSelectionResponse":
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSArtMeshSelectionResponseData>(data));
+                                        break;
+                                    case "EventSubscriptionResponse":
+                                        this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSEventSubscriptionResponseData>(data));
                                         break;
                                     default:
                                         VTSErrorData error = new VTSErrorData();
@@ -194,12 +283,18 @@ namespace VTS.Networking {
             }
         }
 
-        public void Send<T>(T request, Action<T> onSuccess, Action<VTSErrorData> onError) where T : VTSMessageData{
-            if(this._ws != null && this._ws.IsConnectionOpen()){
+        public void Disconnect(){
+            if(this._ws != null){
+                this._ws.Stop();
+            }
+        }
+
+        public void Send<T, K>(T request, Action<K> onSuccess, Action<VTSErrorData> onError) where T : VTSMessageData where K : VTSMessageData{
+            if(this._ws != null){
                 try{
-                    this._callbacks.Add(request.requestID, new VTSCallbacks((t) => { onSuccess((T)t); } , onError));
+                    this._callbacks.Add(request.requestID, new VTSCallbacks((k) => { onSuccess((K)k); }, onError));
                     // make sure to remove null properties
-                    string output = _json.ToJson(request);
+                    string output = this._json.ToJson(request);
                     this._ws.Send(output);
                 }catch(Exception e){
                     Debug.LogError(e);
@@ -216,24 +311,47 @@ namespace VTS.Networking {
             }
         }
 
-        public Dictionary<int, VTSStateBroadcastData> GetPorts(){
-            return new Dictionary<int, VTSStateBroadcastData>(PORTS);
+        public void SendEventSubscription<T, K>(T request, Action<K> onEvent, Action<VTSEventSubscriptionResponseData> onSubscribe, Action<VTSErrorData> onError, Action resubscribe) where T : VTSEventSubscriptionRequestData where K : VTSEventData{
+            this.Send<T, VTSEventSubscriptionResponseData>(
+                request, 
+                (s) => {
+                    // add event or remove event from register
+                    if(this._events.ContainsKey(request.GetEventName())){
+                        this._events.Remove(request.GetEventName());
+                    }
+                    if(request.GetSubscribed()){
+                        this._events.Add(request.GetEventName(), new VTSEventCallbacks((k) => { onEvent((K)k); }, onError, resubscribe));
+                    }
+                    onSubscribe(s);
+                },
+                onError);
         }
 
-        public bool SetPort(int port){
-            if(PORTS.ContainsKey(port)){
-                this._port = port;
-                return true;
+        public void ResubscribeToEvents(){
+            foreach(VTSEventCallbacks callback in this._events.Values){
+                callback.resubscribe();
             }
-            return false;
         }
 
-        private struct VTSCallbacks{
+        #endregion
+
+        private struct VTSCallbacks {
             public Action<VTSMessageData> onSuccess; 
             public Action<VTSErrorData> onError;
             public VTSCallbacks(Action<VTSMessageData> onSuccess, Action<VTSErrorData> onError){
                 this.onSuccess = onSuccess;
                 this.onError = onError;
+            }
+        }
+
+        private struct VTSEventCallbacks {
+            public Action<VTSEventData> onEvent;
+            public Action<VTSErrorData> onError;
+            public Action resubscribe;
+            public VTSEventCallbacks(Action<VTSEventData> onEvent, Action<VTSErrorData> onError, Action resubscribe){
+                this.onEvent = onEvent;
+                this.onError = onError;
+                this.resubscribe = resubscribe;
             }
         }
     }

--- a/Assets/Core/VTS/Networking/VTSWebSocket.cs
+++ b/Assets/Core/VTS/Networking/VTSWebSocket.cs
@@ -43,10 +43,12 @@ namespace VTS.Networking {
         }
 
         private void OnDestroy(){
-            this._ws.Stop();
+            if(this._ws != null){
+                this._ws.Stop();
+            }
         }
 
-        private void FixedUpdate(){
+        private void Update(){
             ProcessResponses();
             CheckPorts();
         }
@@ -73,6 +75,9 @@ namespace VTS.Networking {
                             PORTS.Remove(data.data.port);
                         }
                         PORTS.Add(data.data.port, data);
+                        // if(!PORTS.ContainsKey(this._port) && PORTS.Count == 1){
+                        //     onPortChange(data.data.port);
+                        // }
                     }
                 }
                 

--- a/Assets/Core/VTS/Networking/VTSWebSocket.cs
+++ b/Assets/Core/VTS/Networking/VTSWebSocket.cs
@@ -13,12 +13,13 @@ namespace VTS.Networking {
     /// <summary>
     /// Underlying VTS socket connection and response processor.
     /// </summary>
-    public class VTSWebSocket : MonoBehaviour
-    {
+    public class VTSWebSocket : MonoBehaviour {
         // Dependencies
         private const string VTS_WS_URL = "ws://{0}:{1}";
         private IPAddress _ip = IPAddress.Loopback;
-        private int _port = 8001;
+        private const int DEFAULT_PORT = 8001;
+        private int _port = DEFAULT_PORT;
+        public int Port { get { return this._port; } }
         private IWebSocket _ws = null;
         private IJsonUtility _json = null;
 
@@ -27,41 +28,54 @@ namespace VTS.Networking {
         private Dictionary<string, VTSEventCallbacks> _events = new Dictionary<string, VTSEventCallbacks>();
 
         // UDP 
+        private const int UDP_DEFAULT_PORT = 47779;
         private static UdpClient UDP_CLIENT = null;
         private static Task<UdpReceiveResult> UDP_RESULT = null;
         private static readonly Dictionary<int, VTSStateBroadcastData> PORTS = new Dictionary<int, VTSStateBroadcastData>();
 
-        public delegate void PortDiscoveryEvent(VTSStateBroadcastData portData);
-        public static event PortDiscoveryEvent OnPortDiscovered;
+        private static event Action<int> GLOBAL_PORT_DISCOVERY_EVENT;
+
+        private Action<int> _onPortDiscovered = null;
+        private const float DEFAULT_PORT_DISCOVERY_TIMEOUT = 3f;
+        private float _portDiscoveryTimer = 0;
+        private Action _onPortDiscoveryTimeout = null;
 
         #region Lifecycle
 
-        /*
-        TODO: make a static event that executes every time the list of ports updates, with the new port
-        Then, in the plugin Initialize method, don't attempt connection/auth until we get the first execution of this event.
-        Correct to the first port you find.
-
-        We should also use the this.Socket accessor internally, and have that do the getComponent<...>() call so we have the socket when we need it.
-        */
-
         public void Initialize(IWebSocket webSocket, IJsonUtility jsonUtility){
-            if(this._ws != null){
-                this._ws.Stop();
+            if(this._ws == null){
+                // Only add this listener to the event the first time we initialize.
+                GLOBAL_PORT_DISCOVERY_EVENT += OnPortDiscovered;
             }
+            // Stop existing socket.
+            Disconnect();
+
             this._ws = webSocket;
             this._json = jsonUtility;
             StartUDP();
         }
 
         private void OnDestroy(){
-            if(this._ws != null){
-                this._ws.Stop();
-            }
+            GLOBAL_PORT_DISCOVERY_EVENT -= OnPortDiscovered;
+            Disconnect();
         }
 
         private void Update(){
+            Update(Time.deltaTime);
+        }
+
+        private void Update(float timeDelta){
             ProcessResponses();
             CheckPorts();
+            if(this._portDiscoveryTimer > 0f){
+                this._portDiscoveryTimer -= timeDelta;
+                if(this._portDiscoveryTimer <= 0f){
+                    if(this._onPortDiscoveryTimeout != null){
+                        this._onPortDiscoveryTimeout.Invoke();
+                    }
+                    this._portDiscoveryTimer = 0f;
+                }
+            }
         }
 
         #endregion
@@ -86,10 +100,7 @@ namespace VTS.Networking {
                             PORTS.Remove(data.data.port);
                         }
                         PORTS.Add(data.data.port, data);
-                        OnPortDiscovered.Invoke(data);
-                        // if(!PORTS.ContainsKey(this._port) && PORTS.Count == 1){
-                        //     onPortChange(data.data.port);
-                        // }
+                        GLOBAL_PORT_DISCOVERY_EVENT.Invoke(data.data.port);
                     }
                 }
                 
@@ -99,11 +110,11 @@ namespace VTS.Networking {
             }
         }
 
-        private void StartUDP(){
+        private static void StartUDP(){
             try{
                 if(UDP_CLIENT == null){
                     // This configuration should prevent the UDP client from blocking other connections to the port
-                    IPEndPoint LOCAL_PT = new IPEndPoint(IPAddress.Any, 47779);
+                    IPEndPoint LOCAL_PT = new IPEndPoint(IPAddress.Any, UDP_DEFAULT_PORT);
                     UDP_CLIENT = new UdpClient();
                     UDP_CLIENT.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
                     UDP_CLIENT.Client.Bind(LOCAL_PT);
@@ -112,31 +123,161 @@ namespace VTS.Networking {
                 Debug.LogError(e);
             }
         }
+
+        private void OnPortDiscovered(int port){
+            if(this._onPortDiscovered != null){
+                Debug.Log(string.Format("Available VTube Studio port discovered: {0}!", port));
+                this._onPortDiscovered.Invoke(port);
+            }
+        }
         
         public Dictionary<int, VTSStateBroadcastData> GetPorts(){
             return new Dictionary<int, VTSStateBroadcastData>(PORTS);
         }
 
+        /// <summary>
+        /// Sets the connection port to the given number. Returns true if the port is a valid VTube Studio port, returns false otherwise. 
+        /// If the port number is changed while an active connection exists, you will need to reconnect.
+        /// </summary>
+        /// <param name="port">The port to connect to.</param>
+        /// <returns>True if the port is a valid VTube Studio port, False otherwise.</returns>
         public bool SetPort(int port){
+            Debug.Log(string.Format("Setting port: {0}...", port));
+            this._port = port;
             if(PORTS.ContainsKey(port)){
-                this._port = port;
+                Debug.Log(string.Format("Port {0} is a known VTube Studio Port.", port));
                 return true;
             }
+            Debug.LogWarning(string.Format("Port {0} is not a known VTube Studio Port!", port));
             return false;
         }
 
+        /// <summary>
+        /// Sets the connection IP address to the given string. Returns true if the string is a valid IP Address format, returns false otherwise.
+        /// If the IP Address is changed while an active connection exists, you will need to reconnect.
+        /// </summary>
+        /// <param name="ipString">The string form of the IP address, in dotted-quad notation for IPv4.</param>
+        /// <returns>True if the string is a valid IP Address format, False otherwise.</returns>
         public bool SetIPAddress(string ipString){
             IPAddress address;
+            Debug.Log(string.Format("Setting IP address: {0}...", ipString));
             if(IPAddress.TryParse(ipString, out address)){
                 this._ip = address;
+                Debug.Log(string.Format("IP address {0} is valid IPv4 format.", ipString));
                 return true;
             }
+            Debug.LogWarning(string.Format("IP address {0} is not valid IPv4 format! Unable to set.", ipString));
             return false;
         }
 
         #endregion
 
         #region I/O
+
+        /// <summary>
+        /// Connects to VTube Studio on the current port, executing the provided callbacks during different phases of the connection lifecycle.
+        /// Will first attempt to connect to the designated port. 
+        /// If that fails, it will attempt to find the first port discovered by UDP. 
+        /// If that takes too long and times out, it will attempt to connect to the default port.
+        /// </summary>
+        /// <param name="onConnect">Callback executed upon successful initialization.</param>
+        /// <param name="onDisconnect">Callback executed upon disconnecting from VTS.</param>
+        /// <param name="onError">The Callback executed upon failed initialization.</param>
+        public void Connect(Action onConnect, Action onDisconnect, Action onError){
+            // If the port we're trying to connect to isn't a known port...
+            if(!PORTS.ContainsKey(this._port)){
+                // First try to connect to the port we proclaim...
+                ConnectImpl(this._port, onConnect, onDisconnect, () => {
+                    // If that fails, let's try the first port we can find on UDP!
+                    Debug.Log(string.Format("Unable to connect to VTube Studio port {0}, waiting for port discovery...", this._port));
+                    // Create a callback that will forcibly try to connect to the default port, if we cannot discover a port in time.
+                    this._portDiscoveryTimer = DEFAULT_PORT_DISCOVERY_TIMEOUT;
+                    this._onPortDiscoveryTimeout = () => {
+                        Debug.LogError(string.Format("Wait for port discovery has timed out. Finally, attempting connection on default port {1}.", this._port, DEFAULT_PORT));
+                        ClearConnectionCallbacks();
+                        ConnectImpl(DEFAULT_PORT, onConnect, onDisconnect, onError);
+                    };
+                    // Wait until we discover a functional port, then try to connect.
+                    this._onPortDiscovered = (port) => {
+                        ClearConnectionCallbacks();
+                        ConnectImpl(port, onConnect, onDisconnect, onError);
+                    };
+                });
+            }else{
+                ConnectImpl(this._port, onConnect, onDisconnect, onError);
+            }
+        }
+
+        private void ConnectImpl(int port, Action onConnect, Action onDisconnect, Action onError){
+            if(this._ws != null){
+                Disconnect();
+                SetPort(port);
+                this._ws.Start(string.Format(VTS_WS_URL, this._ip.ToString(), this._port), onConnect, onDisconnect, onError);
+            }else{
+                onError.Invoke();
+            }
+        }
+
+        /// <summary>
+        /// Disconnects from VTube Studio.
+        /// </summary>
+        public void Disconnect(){
+            if(this._ws != null){
+                ClearConnectionCallbacks();
+                this._ws.Stop();
+            }
+        }
+
+        private void ClearConnectionCallbacks(){
+            // Wipe the callbacks so we don't keep re-firing them after a successful connection or disconnect.
+            this._onPortDiscovered = null;
+            this._onPortDiscoveryTimeout = null;
+            this._portDiscoveryTimer = 0f;
+        }
+
+        public void Send<T, K>(T request, Action<K> onSuccess, Action<VTSErrorData> onError) where T : VTSMessageData where K : VTSMessageData{
+            if(this._ws != null){
+                try{
+                    this._callbacks.Add(request.requestID, new VTSCallbacks((k) => { onSuccess((K)k); }, onError));
+                    // make sure to remove null properties
+                    string output = this._json.ToJson(request);
+                    this._ws.Send(output);
+                }catch(Exception e){
+                    Debug.LogError(e);
+                    VTSErrorData error = new VTSErrorData();
+                    error.data.errorID = ErrorID.InternalServerError;
+                    error.data.message = e.Message;
+                    onError(error);
+                }
+            }else{
+                VTSErrorData error = new VTSErrorData();
+                error.data.errorID = ErrorID.InternalServerError;
+                error.data.message = "No websocket data";
+                onError(error);
+            }
+        }
+
+        public void SendEventSubscription<T, K>(T request, Action<K> onEvent, Action<VTSEventSubscriptionResponseData> onSubscribe, Action<VTSErrorData> onError, Action resubscribe) where T : VTSEventSubscriptionRequestData where K : VTSEventData{
+            this.Send<T, VTSEventSubscriptionResponseData>(
+                request, 
+                (s) => {
+                    // add event or remove event from register
+                    if(this._events.ContainsKey(request.GetEventName())){
+                        this._events.Remove(request.GetEventName());
+                    }
+                    if(request.GetSubscribed()){
+                        this._events.Add(request.GetEventName(), new VTSEventCallbacks((k) => { onEvent((K)k); }, onError, resubscribe));
+                    }
+                    onSubscribe(s);
+                },
+                onError);
+        }
+
+        public void ResubscribeToEvents(){
+            foreach(VTSEventCallbacks callback in this._events.Values){
+                callback.resubscribe();
+            }
+        }
 
         private void ProcessResponses(){
             string data = null;
@@ -300,64 +441,6 @@ namespace VTS.Networking {
                     }
                 }
             }while(data != null);
-        }
-
-        public void Connect(System.Action onConnect, System.Action onDisconnect, System.Action onError){
-            if(this._ws != null){
-                this._ws.Start(string.Format(VTS_WS_URL, this._ip.ToString(), this._port), onConnect, onDisconnect, onError);
-            }else{
-                onError();
-            }
-        }
-
-        public void Disconnect(){
-            if(this._ws != null){
-                this._ws.Stop();
-            }
-        }
-
-        public void Send<T, K>(T request, Action<K> onSuccess, Action<VTSErrorData> onError) where T : VTSMessageData where K : VTSMessageData{
-            if(this._ws != null){
-                try{
-                    this._callbacks.Add(request.requestID, new VTSCallbacks((k) => { onSuccess((K)k); }, onError));
-                    // make sure to remove null properties
-                    string output = this._json.ToJson(request);
-                    this._ws.Send(output);
-                }catch(Exception e){
-                    Debug.LogError(e);
-                    VTSErrorData error = new VTSErrorData();
-                    error.data.errorID = ErrorID.InternalServerError;
-                    error.data.message = e.Message;
-                    onError(error);
-                }
-            }else{
-                VTSErrorData error = new VTSErrorData();
-                error.data.errorID = ErrorID.InternalServerError;
-                error.data.message = "No websocket data";
-                onError(error);
-            }
-        }
-
-        public void SendEventSubscription<T, K>(T request, Action<K> onEvent, Action<VTSEventSubscriptionResponseData> onSubscribe, Action<VTSErrorData> onError, Action resubscribe) where T : VTSEventSubscriptionRequestData where K : VTSEventData{
-            this.Send<T, VTSEventSubscriptionResponseData>(
-                request, 
-                (s) => {
-                    // add event or remove event from register
-                    if(this._events.ContainsKey(request.GetEventName())){
-                        this._events.Remove(request.GetEventName());
-                    }
-                    if(request.GetSubscribed()){
-                        this._events.Add(request.GetEventName(), new VTSEventCallbacks((k) => { onEvent((K)k); }, onError, resubscribe));
-                    }
-                    onSubscribe(s);
-                },
-                onError);
-        }
-
-        public void ResubscribeToEvents(){
-            foreach(VTSEventCallbacks callback in this._events.Values){
-                callback.resubscribe();
-            }
         }
 
         #endregion

--- a/Assets/Core/VTS/Networking/VTSWebSocket.cs
+++ b/Assets/Core/VTS/Networking/VTSWebSocket.cs
@@ -16,7 +16,8 @@ namespace VTS.Networking {
     public class VTSWebSocket : MonoBehaviour
     {
         // Dependencies
-        private const string VTS_WS_URL = "ws://localhost:{0}";
+        private const string VTS_WS_URL = "ws://{0}:{1}";
+        private IPAddress _ip = IPAddress.Loopback;
         private int _port = 8001;
         private IWebSocket _ws = null;
         private IJsonUtility _json = null;
@@ -102,6 +103,15 @@ namespace VTS.Networking {
         public bool SetPort(int port){
             if(PORTS.ContainsKey(port)){
                 this._port = port;
+                return true;
+            }
+            return false;
+        }
+
+        public bool SetIPAddress(string ipString){
+            IPAddress address;
+            if(IPAddress.TryParse(ipString, out address)){
+                this._ip = address;
                 return true;
             }
             return false;
@@ -277,7 +287,7 @@ namespace VTS.Networking {
 
         public void Connect(System.Action onConnect, System.Action onDisconnect, System.Action onError){
             if(this._ws != null){
-                this._ws.Start(string.Format(VTS_WS_URL, this._port), onConnect, onDisconnect, onError);
+                this._ws.Start(string.Format(VTS_WS_URL, this._ip.ToString(), this._port), onConnect, onDisconnect, onError);
             }else{
                 onError();
             }

--- a/Assets/Core/VTS/Networking/WebSocketSharp/WebSocketSharpImpl.cs
+++ b/Assets/Core/VTS/Networking/WebSocketSharp/WebSocketSharpImpl.cs
@@ -4,10 +4,9 @@ using System.Collections.Concurrent;
 using UnityEngine;
 using WebSocketSharp;
 
-namespace VTS.Networking.Impl{
+namespace VTS.Networking.Impl {
 
-    public class WebSocketSharpImpl : IWebSocket
-    {
+    public class WebSocketSharpImpl : IWebSocket {
         private static UTF8Encoding ENCODER = new UTF8Encoding();
 
         private WebSocket _socket;
@@ -23,31 +22,26 @@ namespace VTS.Networking.Impl{
             this._intakeQueue = new ConcurrentQueue<string>();
         }
 
-        public string GetNextResponse()
-        {
+        public string GetNextResponse(){
             string response = null;
             this._intakeQueue.TryDequeue(out response);
             return response;
         }
 
-        public bool IsConnecting()
-        {
+        public bool IsConnecting(){
             return this._socket != null && this._socket.ReadyState == WebSocketState.Connecting;
         }
 
-        public bool IsConnectionOpen()
-        {
+        public bool IsConnectionOpen() {
             return this._socket != null && this._socket.ReadyState == WebSocketState.Open;
         }
 
-        public void Send(string message)
-        {
+        public void Send(string message){
             // byte[] buffer = ENCODER.GetBytes(message);
             this._socket.SendAsync(message, (success) => {});
         }
 
-        public void Start(string URL, Action onConnect, Action onDisconnect, Action onError)
-        {
+        public void Start(string URL, Action onConnect, Action onDisconnect, Action onError) {
             this._url = URL;
             if(this._socket != null){
                 this._socket.Close();
@@ -67,13 +61,13 @@ namespace VTS.Networking.Impl{
             this._socket.OnOpen += (sender, e) => { 
                 MainThreadUtil.Run(() => {
                     this._onConnect();
-                    Debug.Log(this._socket.Url.Host + " Socket open!");
+                    Debug.Log(string.Format("{0} Socket open!", this._socket.Url.Host));
                     this._attemptReconnect = true;
                 });
             };
             this._socket.OnError += (sender, e) => { 
                 MainThreadUtil.Run(() => {
-                    Debug.LogError(this._socket.Url.Host + " Socket error...");
+                    Debug.LogError(string.Format("{0} Socket error...", this._socket.Url.Host));
                     if(e != null){
                         Debug.LogError(string.Format("'{0}', {1}", e.Message, e.Exception));
                     }
@@ -82,7 +76,7 @@ namespace VTS.Networking.Impl{
             };
             this._socket.OnClose += (sender, e) => { 
                 MainThreadUtil.Run(() => {
-                    Debug.Log(string.Format(this._socket.Url.Host + " Socket closing: {0}, '{1}', {2}", e.Code, e.Reason, e.WasClean));
+                    Debug.Log(string.Format("{0} Socket closing: {1}, '{2}', {3}", this._socket.Url.Host, e.Code, e.Reason, e.WasClean));
                     this._onDisconnect();
                     if(this._attemptReconnect && !e.WasClean){
                         Reconnect();
@@ -93,8 +87,7 @@ namespace VTS.Networking.Impl{
             this._socket.ConnectAsync();
         }
 
-        public void Stop()
-        {
+        public void Stop(){
             this._attemptReconnect = false;
             if(this._socket != null && this._socket.IsAlive){
                 this._socket.Close();

--- a/Assets/Core/VTS/Networking/WebSocketSharp/WebSocketSharpImpl.cs
+++ b/Assets/Core/VTS/Networking/WebSocketSharp/WebSocketSharpImpl.cs
@@ -47,6 +47,7 @@ namespace VTS.Networking.Impl {
                 this._socket.Close();
             }
             this._socket = new WebSocket(this._url);
+            Debug.Log(string.Format("Attempting to connect to {0}", this._socket.Url));
             this._socket.WaitTime = TimeSpan.FromSeconds(10);
             this._onConnect = onConnect;
             this._onDisconnect = onDisconnect;

--- a/Assets/Core/VTS/Networking/WebSocketSharp/WebSocketSharpImpl.cs
+++ b/Assets/Core/VTS/Networking/WebSocketSharp/WebSocketSharpImpl.cs
@@ -43,12 +43,28 @@ namespace VTS.Networking.Impl {
 
         public void Start(string URL, Action onConnect, Action onDisconnect, Action onError) {
             this._url = URL;
-            if(this._socket != null){
-                this._socket.Close();
-            }
+            // WebSocket oldSocket = this._socket;
+            // if(this._socket != null){
+            //     // this._socket.Close();
+            // }
             this._socket = new WebSocket(this._url);
             Debug.Log(string.Format("Attempting to connect to {0}", this._socket.Url));
             this._socket.WaitTime = TimeSpan.FromSeconds(10);
+            this._socket.Log.Output = (l, m) => {
+                switch(l.Level){
+                    case LogLevel.Fatal:
+                    case LogLevel.Trace:
+                    case LogLevel.Error:
+                        Debug.LogError(string.Format("[{0}] - Socket error: {1}", this._socket.Url, l.Message));
+                        break;
+                    case LogLevel.Warn:
+                        Debug.LogError(string.Format("[{0}] - Socket warning: {1}", this._socket.Url, l.Message));
+                        break;
+                    default:
+                        Debug.LogError(string.Format("[{0}] - Socket info: {1}", this._socket.Url, l.Message));
+                        break;
+                }
+            };
             this._onConnect = onConnect;
             this._onDisconnect = onDisconnect;
             this._onError = onError;
@@ -62,13 +78,13 @@ namespace VTS.Networking.Impl {
             this._socket.OnOpen += (sender, e) => { 
                 MainThreadUtil.Run(() => {
                     this._onConnect();
-                    Debug.Log(string.Format("{0} Socket open!", this._socket.Url.Host));
+                    Debug.Log(string.Format("[{0}] - Socket open!", this._socket.Url));
                     this._attemptReconnect = true;
                 });
             };
             this._socket.OnError += (sender, e) => { 
                 MainThreadUtil.Run(() => {
-                    Debug.LogError(string.Format("{0} Socket error...", this._socket.Url.Host));
+                    Debug.LogError(string.Format("[{0}] - Socket error...", this._socket.Url));
                     if(e != null){
                         Debug.LogError(string.Format("'{0}', {1}", e.Message, e.Exception));
                     }
@@ -77,10 +93,16 @@ namespace VTS.Networking.Impl {
             };
             this._socket.OnClose += (sender, e) => { 
                 MainThreadUtil.Run(() => {
-                    Debug.Log(string.Format("{0} Socket closing: {1}, '{2}', {3}", this._socket.Url.Host, e.Code, e.Reason, e.WasClean));
-                    this._onDisconnect();
-                    if(this._attemptReconnect && !e.WasClean){
-                        Reconnect();
+                    string msg = string.Format("[{0}] - Socket closing: {1}, '{2}', {3}", this._socket.Url, e.Code, e.Reason, e.WasClean);
+                    if(e.WasClean){
+                        Debug.Log(msg);
+                        this._onDisconnect();
+                    }else{
+                        Debug.LogError(msg);
+                        this._onError();
+                        if(this._attemptReconnect){
+                            Reconnect();
+                        }
                     }
                 });
             };
@@ -134,7 +156,7 @@ namespace VTS.Networking.Impl {
                     try{
                         action();
                     }catch(Exception e){
-                        Debug.LogError(String.Format("Error from socket: {0}", e.StackTrace));
+                        Debug.LogError(String.Format("Socket error: {0}", e.StackTrace));
                     }
                 }
             }while(CALL_QUEUE.Count > 0);

--- a/Assets/Core/VTS/VTSPlugin.cs
+++ b/Assets/Core/VTS/VTSPlugin.cs
@@ -200,6 +200,16 @@ namespace VTS {
             return this._socket.SetPort(port);
         }
 
+        /// <summary>
+        /// Sets the connection IP address to the given string. Returns true if the string is a valid IP Address format, returns false otherwise.
+        /// If the IP Address is changed while an active connection exists, you will need to reconnect.
+        /// </summary>
+        /// <param name="ipString">The string form of the IP address, in dotted-quad notation for IPv4.</param>
+        /// <returns>True if the string is a valid IP Address format, False otherwise.</returns>
+        public bool SetIPAddress(string ipString){
+            return this._socket.SetIPAddress(ipString);
+        }
+
         #endregion
 
         #region VTS General API Wrapper
@@ -878,7 +888,7 @@ namespace VTS {
         /// <param name="onSubscribe">Callback executed upon successfully subscribing to the event.</param>
         /// <param name="onError">Callback executed upon receiving an error.</param>
         public void SubscribeToModelConfigChangedEvent(Action<VTSModelConfigChangedEventData> onEvent, Action<VTSEventSubscriptionResponseData> onSubscribe, Action<VTSErrorData> onError){
-            SubscribeToEvent<VTSModelConfigChangedEventSubscriptionRequestData, VTSModelConfigChangedEventData>("ModelConfigChangedEvent", true, new VTSBackgroundChangedEventConfigOptions(), onEvent, onSubscribe, onError);
+            SubscribeToEvent<VTSModelConfigChangedEventSubscriptionRequestData, VTSModelConfigChangedEventData>("ModelConfigChangedEvent", true, new VTSModelConfigChangedEventConfigOptions(), onEvent, onSubscribe, onError);
         }
 
         /// <summary>
@@ -900,7 +910,7 @@ namespace VTS {
         /// <param name="onSubscribe">Callback executed upon successfully subscribing to the event.</param>
         /// <param name="onError">Callback executed upon receiving an error.</param>
         public void SubscribeToModelMovedEvent(Action<VTSModelMovedEventData> onEvent, Action<VTSEventSubscriptionResponseData> onSubscribe, Action<VTSErrorData> onError){
-            SubscribeToEvent<VTSModelMovedEventSubscriptionRequestData, VTSModelMovedEventData>("ModelMovedEvent", true, new VTSBackgroundChangedEventConfigOptions(), onEvent, onSubscribe, onError);
+            SubscribeToEvent<VTSModelMovedEventSubscriptionRequestData, VTSModelMovedEventData>("ModelMovedEvent", true, new VTSModelMovedEventConfigOptions(), onEvent, onSubscribe, onError);
         }
 
         /// <summary>

--- a/Assets/Core/VTS/VTSPlugin.cs
+++ b/Assets/Core/VTS/VTSPlugin.cs
@@ -10,8 +10,7 @@ namespace VTS {
     /// The base class for VTS plugin creation.
     /// </summary>
     [RequireComponent(typeof(VTSWebSocket))]
-    public abstract class VTSPlugin : MonoBehaviour
-    {
+    public abstract class VTSPlugin : MonoBehaviour {
         #region Properties
 
         [SerializeField]
@@ -64,7 +63,7 @@ namespace VTS {
         #region Initialization
 
         /// <summary>
-        /// Authenticates the plugin as well as selects the Websocket, JSON utility, and Token Storage implementations.
+        /// Selects the Websocket, JSON utility, and Token Storage implementations, then attempts to Authenticate the plugin.
         /// </summary>
         /// <param name="webSocket">The websocket implementation.</param>
         /// <param name="jsonUtility">The JSON serializer/deserializer implementation.</param>
@@ -76,21 +75,25 @@ namespace VTS {
             this._tokenStorage = tokenStorage;
             this._socket = GetComponent<VTSWebSocket>();
             this._socket.Initialize(webSocket, jsonUtility);
+            Action onCombinedConnect = () => {
+                this._socket.ResubscribeToEvents();
+                onConnect();
+            };
             this._socket.Connect(() => {
                 // If API enabled, authenticate
                 Authenticate(
                     (r) => { 
                         if(!r.data.authenticated){
-                            Reauthenticate(onConnect, onError);
+                            Reauthenticate(onCombinedConnect, onError);
                         }else{
                             this._isAuthenticated = true;
-                            onConnect();
+                            onCombinedConnect();
                         }
                     }, 
                     (r) => { 
                         // If initial authentication fails, try again
                         // (Likely just needs fresh token)
-                        Reauthenticate(onConnect, onError); 
+                        Reauthenticate(onCombinedConnect, onError); 
                     }
                 );
             },
@@ -102,6 +105,15 @@ namespace VTS {
                 this._isAuthenticated = false;
                 onError();
             });
+        }
+
+        /// <summary>
+        /// Disconnects from VTube Studio. Will fire the onDisconnect callback set via the Initialize method.
+        /// </summary>
+        public void Disconnect(){
+            if(this._socket != null){
+                this._socket.Disconnect();
+            }
         }
 
         #endregion
@@ -143,7 +155,7 @@ namespace VTS {
             tokenRequest.data.pluginName = this._pluginName;
             tokenRequest.data.pluginDeveloper = this._pluginAuthor;
             tokenRequest.data.pluginIcon = EncodeIcon(this._pluginIcon);
-            this._socket.Send<VTSAuthData>(tokenRequest,
+            this._socket.Send<VTSAuthData, VTSAuthData>(tokenRequest,
             (a) => {
                 this._token = a.data.authenticationToken; 
                 if(this._tokenStorage != null){
@@ -160,8 +172,7 @@ namespace VTS {
             authRequest.data.pluginName = this._pluginName;
             authRequest.data.pluginDeveloper = this._pluginAuthor;
             authRequest.data.authenticationToken = this._token;
-            authRequest.data.pluginIcon = EncodeIcon(this.PluginIcon);
-            this._socket.Send<VTSAuthData>(authRequest, onSuccess, onError);
+            this._socket.Send<VTSAuthData, VTSAuthData>(authRequest, onSuccess, onError);
         }
 
         #endregion
@@ -191,7 +202,7 @@ namespace VTS {
 
         #endregion
 
-        #region VTS API Wrapper
+        #region VTS General API Wrapper
 
         /// <summary>
         /// Gets the current state of the VTS API.
@@ -203,7 +214,7 @@ namespace VTS {
         /// <param name="onError">Callback executed upon receiving an error.</param>
         public void GetAPIState(Action<VTSStateData> onSuccess, Action<VTSErrorData> onError){
             VTSStateData request = new VTSStateData();
-            this._socket.Send<VTSStateData>(request, onSuccess, onError);
+            this._socket.Send<VTSStateData, VTSStateData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -216,7 +227,7 @@ namespace VTS {
         /// <param name="onError">Callback executed upon receiving an error.</param>
         public void GetStatistics(Action<VTSStatisticsData> onSuccess, Action<VTSErrorData> onError){
             VTSStatisticsData request = new VTSStatisticsData();
-            this._socket.Send<VTSStatisticsData>(request, onSuccess, onError);
+            this._socket.Send<VTSStatisticsData, VTSStatisticsData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -229,7 +240,7 @@ namespace VTS {
         /// <param name="onError">Callback executed upon receiving an error.</param>
         public void GetFolderInfo(Action<VTSFolderInfoData> onSuccess, Action<VTSErrorData> onError){
             VTSFolderInfoData request = new VTSFolderInfoData();
-            this._socket.Send<VTSFolderInfoData>(request, onSuccess, onError);
+            this._socket.Send<VTSFolderInfoData, VTSFolderInfoData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -242,7 +253,7 @@ namespace VTS {
         /// <param name="onError">Callback executed upon receiving an error.</param>
         public void GetCurrentModel(Action<VTSCurrentModelData> onSuccess, Action<VTSErrorData> onError){
             VTSCurrentModelData request = new VTSCurrentModelData();
-            this._socket.Send<VTSCurrentModelData>(request, onSuccess, onError);
+            this._socket.Send<VTSCurrentModelData, VTSCurrentModelData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -255,7 +266,7 @@ namespace VTS {
         /// <param name="onError">Callback executed upon receiving an error.</param>
         public void GetAvailableModels(Action<VTSAvailableModelsData> onSuccess, Action<VTSErrorData> onError){
             VTSAvailableModelsData request = new VTSAvailableModelsData();
-            this._socket.Send<VTSAvailableModelsData>(request, onSuccess, onError);
+            this._socket.Send<VTSAvailableModelsData, VTSAvailableModelsData>(request, onSuccess, onError);
         }
         
         /// <summary>
@@ -270,7 +281,7 @@ namespace VTS {
         public void LoadModel(string modelID, Action<VTSModelLoadData> onSuccess, Action<VTSErrorData> onError){
             VTSModelLoadData request = new VTSModelLoadData();
             request.data.modelID = modelID;
-            this._socket.Send<VTSModelLoadData>(request, onSuccess, onError);
+            this._socket.Send<VTSModelLoadData, VTSModelLoadData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -285,7 +296,7 @@ namespace VTS {
         public void MoveModel(VTSMoveModelData.Data position, Action<VTSMoveModelData> onSuccess, Action<VTSErrorData> onError){
             VTSMoveModelData request = new VTSMoveModelData();
             request.data = position;
-            this._socket.Send<VTSMoveModelData>(request, onSuccess, onError);
+            this._socket.Send<VTSMoveModelData, VTSMoveModelData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -300,9 +311,24 @@ namespace VTS {
         public void GetHotkeysInCurrentModel(string modelID, Action<VTSHotkeysInCurrentModelData> onSuccess, Action<VTSErrorData> onError){
             VTSHotkeysInCurrentModelData request = new VTSHotkeysInCurrentModelData();
             request.data.modelID = modelID;
-            this._socket.Send<VTSHotkeysInCurrentModelData>(request, onSuccess, onError);
+            this._socket.Send<VTSHotkeysInCurrentModelData, VTSHotkeysInCurrentModelData>(request, onSuccess, onError);
         }
         
+        /// <summary>
+        /// Gets a list of available hotkeys for the specified Live2D Item.
+        /// 
+        /// For more info, see 
+        /// <a href="https://github.com/DenchiSoft/VTubeStudio#requesting-list-of-hotkeys-available-in-current-or-other-vts-model">https://github.com/DenchiSoft/VTubeStudio#requesting-list-of-hotkeys-available-in-current-or-other-vts-model</a>
+        /// </summary>
+        /// <param name="live2DItemFileName">Optional, the Live 2D item to get hotkeys for.</param>
+        /// <param name="onSuccess">Callback executed upon receiving a response.</param>
+        /// <param name="onError">Callback executed upon receiving an error.</param>
+        public void GetHotkeysInLive2DItem(string live2DItemFileName, Action<VTSHotkeysInCurrentModelData> onSuccess, Action<VTSErrorData> onError){
+            VTSHotkeysInCurrentModelData request = new VTSHotkeysInCurrentModelData();
+            request.data.live2DItemFileName = live2DItemFileName;
+            this._socket.Send<VTSHotkeysInCurrentModelData, VTSHotkeysInCurrentModelData>(request, onSuccess, onError);
+        }
+
         /// <summary>
         /// Triggers a given hotkey.
         /// 
@@ -315,7 +341,24 @@ namespace VTS {
         public void TriggerHotkey(string hotkeyID, Action<VTSHotkeyTriggerData> onSuccess, Action<VTSErrorData> onError){
             VTSHotkeyTriggerData request = new VTSHotkeyTriggerData();
             request.data.hotkeyID = hotkeyID;
-            this._socket.Send<VTSHotkeyTriggerData>(request, onSuccess, onError);
+            this._socket.Send<VTSHotkeyTriggerData, VTSHotkeyTriggerData>(request, onSuccess, onError);
+        }
+
+        /// <summary>
+        /// Triggers a given hotkey on a specified Live2D item.
+        /// 
+        /// For more info, see 
+        /// <a href="https://github.com/DenchiSoft/VTubeStudio#requesting-execution-of-hotkeys">https://github.com/DenchiSoft/VTubeStudio#requesting-execution-of-hotkeys</a>
+        /// </summary>
+        /// <param name="itemInstanceID">The instance ID of the Live2D item.</param>
+        /// <param name="hotkeyID">The model ID to get hotkeys for.</param>
+        /// <param name="onSuccess">Callback executed upon receiving a response.</param>
+        /// <param name="onError">Callback executed upon receiving an error.</param>
+        public void TriggerHotkeyForLive2DItem(string itemInstanceID, string hotkeyID, Action<VTSHotkeyTriggerData> onSuccess, Action<VTSErrorData> onError){
+            VTSHotkeyTriggerData request = new VTSHotkeyTriggerData();
+            request.data.hotkeyID = hotkeyID;
+            request.data.itemInstanceID = itemInstanceID;
+            this._socket.Send<VTSHotkeyTriggerData, VTSHotkeyTriggerData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -328,7 +371,7 @@ namespace VTS {
         /// <param name="onError">Callback executed upon receiving an error.</param>
         public void GetArtMeshList(Action<VTSArtMeshListData> onSuccess, Action<VTSErrorData> onError){
             VTSArtMeshListData request = new VTSArtMeshListData();
-            this._socket.Send<VTSArtMeshListData>(request, onSuccess, onError);
+            this._socket.Send<VTSArtMeshListData, VTSArtMeshListData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -345,11 +388,11 @@ namespace VTS {
         public void TintArtMesh(Color32 tint, float mixWithSceneLightingColor,  ArtMeshMatcher matcher, Action<VTSColorTintData> onSuccess, Action<VTSErrorData> onError){
             VTSColorTintData request = new VTSColorTintData();
             ArtMeshColorTint colorTint = new ArtMeshColorTint();
-            colorTint.fromColor32(tint);
+            colorTint.FromColor32(tint);
             colorTint.mixWithSceneLightingColor = System.Math.Min(1, System.Math.Max(mixWithSceneLightingColor, 0));
             request.data.colorTint = colorTint;
             request.data.artMeshMatcher = matcher;
-            this._socket.Send<VTSColorTintData>(request, onSuccess, onError);
+            this._socket.Send<VTSColorTintData, VTSColorTintData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -362,7 +405,7 @@ namespace VTS {
         /// <param name="onError"></param>
         public void GetSceneColorOverlayInfo(Action<VTSSceneColorOverlayData> onSuccess, Action<VTSErrorData> onError){
             VTSSceneColorOverlayData request = new VTSSceneColorOverlayData();
-            this._socket.Send<VTSSceneColorOverlayData>(request, onSuccess, onError);
+            this._socket.Send<VTSSceneColorOverlayData, VTSSceneColorOverlayData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -375,7 +418,7 @@ namespace VTS {
         /// <param name="onError">Callback executed upon receiving an error.</param>
         public void GetFaceFound(Action<VTSFaceFoundData> onSuccess, Action<VTSErrorData> onError){
             VTSFaceFoundData request = new VTSFaceFoundData();
-            this._socket.Send<VTSFaceFoundData>(request, onSuccess, onError);
+            this._socket.Send<VTSFaceFoundData, VTSFaceFoundData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -388,7 +431,7 @@ namespace VTS {
         /// <param name="onError">Callback executed upon receiving an error.</param>
         public void GetInputParameterList(Action<VTSInputParameterListData> onSuccess, Action<VTSErrorData> onError){
             VTSInputParameterListData request = new VTSInputParameterListData();
-            this._socket.Send<VTSInputParameterListData>(request, onSuccess, onError);
+            this._socket.Send<VTSInputParameterListData, VTSInputParameterListData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -403,7 +446,7 @@ namespace VTS {
         public void GetParameterValue(string parameterName, Action<VTSParameterValueData> onSuccess, Action<VTSErrorData> onError){
             VTSParameterValueData request = new VTSParameterValueData();
             request.data.name = parameterName;
-            this._socket.Send<VTSParameterValueData>(request, onSuccess, onError);
+            this._socket.Send<VTSParameterValueData, VTSParameterValueData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -416,7 +459,7 @@ namespace VTS {
         /// <param name="onError">Callback executed upon receiving an error.</param>
         public void GetLive2DParameterList(Action<VTSLive2DParameterListData> onSuccess, Action<VTSErrorData> onError){
             VTSLive2DParameterListData request = new VTSLive2DParameterListData();
-            this._socket.Send<VTSLive2DParameterListData>(request, onSuccess, onError);
+            this._socket.Send<VTSLive2DParameterListData, VTSLive2DParameterListData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -435,7 +478,7 @@ namespace VTS {
             request.data.min = parameter.min;
             request.data.max = parameter.max;
             request.data.defaultValue = parameter.defaultValue;
-            this._socket.Send<VTSParameterCreationData>(request, onSuccess, onError);
+            this._socket.Send<VTSParameterCreationData, VTSParameterCreationData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -450,7 +493,7 @@ namespace VTS {
         public void RemoveCustomParameter(string parameterName, Action<VTSParameterDeletionData> onSuccess, Action<VTSErrorData> onError){
             VTSParameterDeletionData request = new VTSParameterDeletionData();
             request.data.parameterName = SanitizeParameterName(parameterName);
-            this._socket.Send<VTSParameterDeletionData>(request, onSuccess, onError);
+            this._socket.Send<VTSParameterDeletionData, VTSParameterDeletionData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -463,12 +506,43 @@ namespace VTS {
         /// <param name="onSuccess">Callback executed upon receiving a response.</param>
         /// <param name="onError">Callback executed upon receiving an error.</param>
         public void InjectParameterValues(VTSParameterInjectionValue[] values, Action<VTSInjectParameterData> onSuccess, Action<VTSErrorData> onError){
+            InjectParameterValues(values, VTSInjectParameterMode.SET, false, onSuccess, onError);
+        }
+
+        /// <summary>
+        /// Sends a list of parameter names and corresponding values to assign to them.
+        /// 
+        /// For more info, see 
+        /// <a href="https://github.com/DenchiSoft/VTubeStudio#feeding-in-data-for-default-or-custom-parameters">https://github.com/DenchiSoft/VTubeStudio#feeding-in-data-for-default-or-custom-parameters</a>
+        /// </summary>
+        /// <param name="values">A list of parameters and the values to assign to them.</param>
+        /// <param name="mode">The method by which the parameter values are applied.</param>
+        /// <param name="onSuccess">Callback executed upon receiving a response.</param>
+        /// <param name="onError">Callback executed upon receiving an error.</param>
+        public void InjectParameterValues(VTSParameterInjectionValue[] values, VTSInjectParameterMode mode, Action<VTSInjectParameterData> onSuccess, Action<VTSErrorData> onError){
+            InjectParameterValues(values, mode, false, onSuccess, onError);
+        }
+
+        /// <summary>
+        /// Sends a list of parameter names and corresponding values to assign to them.
+        /// 
+        /// For more info, see 
+        /// <a href="https://github.com/DenchiSoft/VTubeStudio#feeding-in-data-for-default-or-custom-parameters">https://github.com/DenchiSoft/VTubeStudio#feeding-in-data-for-default-or-custom-parameters</a>
+        /// </summary>
+        /// <param name="values">A list of parameters and the values to assign to them.</param>
+        /// <param name="mode">The method by which the parameter values are applied.</param>
+        /// <param name="faceFound">A flag which can be set to True to tell VTube Studio to consider the user face as found.</param>
+        /// <param name="onSuccess">Callback executed upon receiving a response.</param>
+        /// <param name="onError">Callback executed upon receiving an error.</param>
+        public void InjectParameterValues(VTSParameterInjectionValue[] values, VTSInjectParameterMode mode, bool faceFound, Action<VTSInjectParameterData> onSuccess, Action<VTSErrorData> onError){
             VTSInjectParameterData request = new VTSInjectParameterData();
             foreach(VTSParameterInjectionValue value in values){
                 value.id = SanitizeParameterName(value.id);
             }
+            request.data.faceFound = faceFound;
             request.data.parameterValues = values;
-            this._socket.Send<VTSInjectParameterData>(request, onSuccess, onError);
+            request.data.mode = InjectParameterModeToString(mode);
+            this._socket.Send<VTSInjectParameterData, VTSInjectParameterData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -482,7 +556,7 @@ namespace VTS {
         public void GetExpressionStateList(Action<VTSExpressionStateData> onSuccess, Action<VTSErrorData> onError){
             VTSExpressionStateData request = new VTSExpressionStateData();
             request.data.details = true;
-            this._socket.Send<VTSExpressionStateData>(request, onSuccess, onError);
+            this._socket.Send<VTSExpressionStateData, VTSExpressionStateData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -499,11 +573,41 @@ namespace VTS {
             VTSExpressionActivationData request = new VTSExpressionActivationData();
             request.data.expressionFile = expression;
             request.data.active = active;
-            this._socket.Send<VTSExpressionActivationData>(request, onSuccess, onError);
+            this._socket.Send<VTSExpressionActivationData, VTSExpressionActivationData>(request, onSuccess, onError);
         }
 
         /// <summary>
-        /// Changes the DNI configuration.
+        /// Gets physics information about the currently loaded model.
+        /// 
+        /// For more info, see
+        /// <a href="https://github.com/DenchiSoft/VTubeStudio#getting-physics-settings-of-currently-loaded-vts-model">https://github.com/DenchiSoft/VTubeStudio#getting-physics-settings-of-currently-loaded-vts-model</a>
+        /// </summary>
+        /// <param name="onSuccess">Callback executed upon receiving a response.</param>
+        /// <param name="onError">Callback executed upon receiving an error.</param>
+        public void GetCurrentModelPhysics(Action<VTSCurrentModelPhysicsData> onSuccess, Action<VTSErrorData> onError){
+            VTSCurrentModelPhysicsData request = new VTSCurrentModelPhysicsData();
+            this._socket.Send<VTSCurrentModelPhysicsData, VTSCurrentModelPhysicsData>(request, onSuccess, onError);
+        }
+
+        /// <summary>
+        /// Overrides the physics properties of the current model. Once a plugin has overridden a model's physics, no other plugins may do so.
+        /// 
+        /// For more info, see
+        /// <a href="https://github.com/DenchiSoft/VTubeStudio#overriding-physics-settings-of-currently-loaded-vts-model">https://github.com/DenchiSoft/VTubeStudio#overriding-physics-settings-of-currently-loaded-vts-model</a>
+        /// </summary>
+        /// <param name="strengthOverrides">A list of strength override settings </param>
+        /// <param name="windOverrides">A list of wind override settings.</param>
+        /// <param name="onSuccess">Callback executed upon receiving a response.</param>
+        /// <param name="onError">Callback executed upon receiving an error.</param>
+        public void SetCurrentModelPhysics(VTSPhysicsOverride[] strengthOverrides, VTSPhysicsOverride[] windOverrides, Action<VTSOverrideModelPhysicsData> onSuccess, Action<VTSErrorData> onError){
+            VTSOverrideModelPhysicsData request = new VTSOverrideModelPhysicsData();
+            request.data.strengthOverrides = strengthOverrides;
+            request.data.windOverrides = windOverrides;
+            this._socket.Send<VTSOverrideModelPhysicsData, VTSOverrideModelPhysicsData>(request, onSuccess, onError);
+        }
+
+        /// <summary>
+        /// Changes the NDI configuration.
         /// 
         /// For more info, see 
         /// <a href="https://github.com/DenchiSoft/VTubeStudio#get-and-set-ndi-settings">https://github.com/DenchiSoft/VTubeStudio#get-and-set-ndi-settings</a>
@@ -512,15 +616,339 @@ namespace VTS {
         /// <param name="onSuccess">Callback executed upon receiving a response.</param>
         /// <param name="onError">Callback executed upon receiving an error.</param>
         public void SetNDIConfig(VTSNDIConfigData config, Action<VTSNDIConfigData> onSuccess, Action<VTSErrorData> onError){
-            this._socket.Send<VTSNDIConfigData>(config, onSuccess, onError);
+            this._socket.Send<VTSNDIConfigData, VTSNDIConfigData>(config, onSuccess, onError);
         }
+
+        /// <summary>
+        /// Retrieves a list of items, either in the scene or available as files, based on the provided options.
+        /// 
+        /// For more, see 
+        /// <a href="https://github.com/DenchiSoft/VTubeStudio#requesting-list-of-available-items-or-items-in-scene">https://github.com/DenchiSoft/VTubeStudio#requesting-list-of-available-items-or-items-in-scene</a>
+        /// </summary>
+        /// <param name="options">Configuration options about the request.</param>
+        /// <param name="onSuccess">Callback executed upon receiving a response.</param>
+        /// <param name="onError">Callback executed upon receiving an error.</param>
+        public void GetItemList(VTSItemListOptions options, Action<VTSItemListResponseData> onSuccess, Action<VTSErrorData> onError){
+            VTSItemListRequestData request = new VTSItemListRequestData();
+            request.data.includeAvailableSpots = options.includeAvailableSpots;
+            request.data.includeItemInstancesInScene = options.includeItemInstancesInScene;
+            request.data.includeAvailableItemFiles = options.includeAvailableItemFiles;
+            request.data.onlyItemsWithFileName = options.onlyItemsWithFileName;
+            request.data.onlyItemsWithInstanceID = options.onlyItemsWithInstanceID;
+            this._socket.Send<VTSItemListRequestData, VTSItemListResponseData>(request, onSuccess, onError);
+        }
+
+        /// <summary>
+        /// Loads an item into the scene, with properties based on the provided options.
+        /// 
+        /// For more, see 
+        /// <a href="https://github.com/DenchiSoft/VTubeStudio#loading-item-into-the-scene">https://github.com/DenchiSoft/VTubeStudio#loading-item-into-the-scene</a>
+        /// </summary>
+        /// <param name="fileName">The file name of the item to load, typically retrieved from an ItemListRequest.</param>
+        /// <param name="options">Configuration options about the request.</param>
+        /// <param name="onSuccess">Callback executed upon receiving a response.</param>
+        /// <param name="onError">Callback executed upon receiving an error.</param>
+        public void LoadItem(string fileName, VTSItemLoadOptions options, Action<VTSItemLoadResponseData> onSuccess, Action<VTSErrorData> onError){
+            VTSItemLoadRequestData request = new VTSItemLoadRequestData();
+            request.data.fileName = fileName;
+            request.data.positionX = options.positionX;
+            request.data.positionY = options.positionY;
+            request.data.size = options.size;
+            request.data.rotation = options.rotation;
+            request.data.fadeTime = options.fadeTime;
+            request.data.order = options.order;
+            request.data.failIfOrderTaken = options.failIfOrderTaken;
+            request.data.smoothing = options.smoothing;
+            request.data.censored = options.censored;
+            request.data.flipped = options.flipped;
+            request.data.locked = options.locked;
+            request.data.unloadWhenPluginDisconnects = options.unloadWhenPluginDisconnects;
+            this._socket.Send<VTSItemLoadRequestData, VTSItemLoadResponseData>(request, onSuccess, onError);
+        }
+
+        /// <summary>
+        /// Unload items from the scene, either broadly, by identifier, or by file name, based on the provided options.
+        /// 
+        /// For more, see 
+        /// <a href="https://github.com/DenchiSoft/VTubeStudio#removing-item-from-the-scene">https://github.com/DenchiSoft/VTubeStudio#removing-item-from-the-scene</a>
+        /// </summary>
+        /// <param name="options">Configuration options about the request.</param>
+        /// <param name="onSuccess">Callback executed upon receiving a response.</param>
+        /// <param name="onError">Callback executed upon receiving an error.</param>
+        public void UnloadItem(VTSItemUnloadOptions options, Action<VTSItemUnloadResponseData> onSuccess, Action<VTSErrorData> onError){
+            VTSItemUnloadRequestData request = new VTSItemUnloadRequestData();
+            request.data.instanceIDs = options.itemInstanceIDs;
+            request.data.fileNames = options.fileNames;
+            request.data.unloadAllInScene = options.unloadAllInScene;
+            request.data.unloadAllLoadedByThisPlugin = options.unloadAllLoadedByThisPlugin;
+            request.data.allowUnloadingItemsLoadedByUserOrOtherPlugins = options.allowUnloadingItemsLoadedByUserOrOtherPlugins;
+            this._socket.Send<VTSItemUnloadRequestData, VTSItemUnloadResponseData>(request, onSuccess, onError);
+        }
+
+        /// <summary>
+        /// Alters the properties of the item of the specified ID based on the provided options.
+        /// 
+        /// For more info, see 
+        /// <a href="https://github.com/DenchiSoft/VTubeStudio#controling-items-and-item-animations">https://github.com/DenchiSoft/VTubeStudio#controling-items-and-item-animations</a>
+        /// <param name="itemInstanceID">The ID of the item to move.</param>
+        /// <param name="options">Configuration options about the request.</param>
+        /// <param name="onSuccess">Callback executed upon receiving a response.</param>
+        /// <param name="onError">Callback executed upon receiving an error.</param>
+        public void AnimateItem(string itemInstanceID, VTSItemAnimationControlOptions options, Action<VTSItemAnimationControlResponseData> onSuccess, Action<VTSErrorData> onError){
+            VTSItemAnimationControlRequestData request = new VTSItemAnimationControlRequestData();
+            request.data.itemInstanceID = itemInstanceID;
+            request.data.framerate = options.framerate;
+            request.data.frame = options.frame;
+            request.data.brightness = options.brightness;
+            request.data.opacity = options.opacity;
+            request.data.setAutoStopFrames = options.setAutoStopFrames;
+            request.data.autoStopFrames = options.autoStopFrames;
+            request.data.setAnimationPlayState = options.setAnimationPlayState;
+            request.data.animationPlayState = options.animationPlayState;
+            this._socket.Send<VTSItemAnimationControlRequestData, VTSItemAnimationControlResponseData>(request, onSuccess, onError);
+        }
+
+        /// <summary>
+        /// Moves the items of the specified IDs based on their provided options.
+        /// 
+        /// For more info, see 
+        /// <a href="https://github.com/DenchiSoft/VTubeStudio#moving-items-in-the-scene">https://github.com/DenchiSoft/VTubeStudio#moving-items-in-the-scene</a>
+        /// </summary>
+        /// <param name="items">The list of Item Insance IDs and their corresponding movement options</param>
+        /// <param name="onSuccess">Callback executed upon receiving a response.</param>
+        /// <param name="onError">Callback executed upon receiving an error.</param>
+        public void MoveItem(VTSItemMoveEntry[] items, Action<VTSItemMoveResponseData> onSuccess, Action<VTSErrorData> onError){
+            VTSItemMoveRequestData request = new VTSItemMoveRequestData();
+            request.data.itemsToMove = new VTSItemToMove[items.Length];
+            for(int i = 0; i < items.Length; i++){
+                VTSItemMoveEntry entry = items[i];
+                request.data.itemsToMove[i] = new VTSItemToMove(
+                    entry.itemInsanceID,
+                    entry.options.timeInSeconds,
+                    MotionCurveToString(entry.options.fadeMode),
+                    entry.options.positionX,
+                    entry.options.positionY,
+                    entry.options.size,
+                    entry.options.rotation,
+                    entry.options.order,
+                    entry.options.setFlip,
+                    entry.options.flip,
+                    entry.options.userCanStop
+                );
+            }
+            this._socket.Send<VTSItemMoveRequestData, VTSItemMoveResponseData>(request, onSuccess, onError);
+        }
+
+        public void RequestArtMeshSelection(string textOverride, string helpOverride, int count, 
+            ICollection<string> activeArtMeshes, 
+            Action<VTSArtMeshSelectionResponseData> onSuccess, Action<VTSErrorData> onError){
+            VTSArtMeshSelectionRequestData request = new VTSArtMeshSelectionRequestData();
+            request.data.textOverride = textOverride;
+            request.data.helpOverride = helpOverride;
+            request.data.requestedArtMeshCount = count;
+            string[] array = new string[activeArtMeshes.Count];
+            activeArtMeshes.CopyTo(array, 0);
+            request.data.activeArtMeshes = array;
+
+            this._socket.Send<VTSArtMeshSelectionRequestData, VTSArtMeshSelectionResponseData>(request, onSuccess, onError);
+        }
+
+        #endregion
+
+        #region VTS Event Subscription API Wrapper
+
+        private void SubscribeToEvent<T, K>(string eventName, bool subscribed, VTSEventConfigData config, Action<K> onEvent, Action<VTSEventSubscriptionResponseData> onSubscribe, Action<VTSErrorData> onError) where T : VTSEventSubscriptionRequestData, new() where K : VTSEventData {
+            T request = new T();
+            request.SetEventName(eventName);
+            request.SetSubscribed(subscribed);
+            if(config != null){
+                request.SetConfig(config);
+            }
+            this._socket.SendEventSubscription<T, K>(request, onEvent, onSubscribe, onError, () => {
+                SubscribeToEvent<T, K>(eventName, subscribed, config, onEvent, onSubscribe, onError);
+            });
+        }
+
+        /// <summary>
+        /// Unsubscribes from all events.
+        /// </summary>
+        /// <param name="onUnsubscribe">Callback executed upon successfully unsubscribing to the event.</param>
+        /// <param name="onError">Callback executed upon receiving an error.</param>
+        public void UnsubscribeFromAllEvents(Action<VTSEventSubscriptionResponseData> onUnsubscribe, Action<VTSErrorData> onError){
+            SubscribeToEvent<VTSTestEventSubscriptionRequestData, VTSTestEventData>(null, false, null, DoNothingCallback, onUnsubscribe, onError);
+        }
+
+        /// <summary>
+        /// Subscribes to the Test Event for testing the event API. Can be configured with a message to echo back every second.
+        /// 
+        /// For more info, see 
+        /// <a href="https://github.com/DenchiSoft/VTubeStudio/blob/master/Events/README.md#test-event">https://github.com/DenchiSoft/VTubeStudio/blob/master/Events/README.md#test-event</a>
+        /// </summary>
+        /// <param name="config">Configuration options about the subscription.</param>
+        /// <param name="onEvent">Callback to execute upon receiving an event.</param>
+        /// <param name="onSubscribe">Callback executed upon successfully subscribing to the event.</param>
+        /// <param name="onError">Callback executed upon receiving an error.</param>
+        public void SubscribeToTestEvent(VTSTestEventConfigOptions config, Action<VTSTestEventData> onEvent, Action<VTSEventSubscriptionResponseData> onSubscribe, Action<VTSErrorData> onError){
+            SubscribeToEvent<VTSTestEventSubscriptionRequestData, VTSTestEventData>("TestEvent", true, config, onEvent, onSubscribe, onError);
+        }
+
+        /// <summary>
+        /// Unsubscribes from the Test Event.
+        /// </summary>
+        /// <param name="onUnsubscribe">Callback executed upon successfully unsubscribing from the event.</param>
+        /// <param name="onError">Callback executed upon receiving an error.</param>
+        public void UnsubscribeFromTestEvent(Action<VTSEventSubscriptionResponseData> onUnsubscribe, Action<VTSErrorData> onError){
+            SubscribeToEvent<VTSTestEventSubscriptionRequestData, VTSTestEventData>("TestEvent", false, null, DoNothingCallback, onUnsubscribe, onError);
+        }
+
+        /// <summary>
+        /// Subscribes to the Model Loaded Event. Can be configured with a model ID to only recieve events about the given model.
+        /// 
+        /// For more info, see 
+        /// <a href="https://github.com/DenchiSoft/VTubeStudio/blob/master/Events/README.md#model-loadedunloaded">https://github.com/DenchiSoft/VTubeStudio/blob/master/Events/README.md#model-loadedunloaded</a>
+        /// </summary>
+        /// <param name="config">Configuration options about the subscription.</param>
+        /// <param name="onEvent">Callback to execute upon receiving an event.</param>
+        /// <param name="onSubscribe">Callback executed upon successfully subscribing to the event.</param>
+        /// <param name="onError">Callback executed upon receiving an error.</param>
+        public void SubscribeToModelLoadedEvent(VTSModelLoadedEventConfigOptions config, Action<VTSModelLoadedEventData> onEvent, Action<VTSEventSubscriptionResponseData> onSubscribe, Action<VTSErrorData> onError){
+            SubscribeToEvent<VTSModelLoadedEventSubscriptionRequestData, VTSModelLoadedEventData>("ModelLoadedEvent", true, config, onEvent, onSubscribe, onError);
+        }
+
+        /// <summary>
+        /// Unsubscribes from the Model Loaded Event.
+        /// </summary>
+        /// <param name="onUnsubscribe">Callback executed upon successfully unsubscribing from the event.</param>
+        /// <param name="onError">Callback executed upon receiving an error.</param>
+        public void UnsubscribeFromModelLoadedEvent(Action<VTSEventSubscriptionResponseData> onUnsubscribe, Action<VTSErrorData> onError){
+            SubscribeToEvent<VTSModelLoadedEventSubscriptionRequestData, VTSTestEventData>("ModelLoadedEvent", false, null, DoNothingCallback, onUnsubscribe, onError);
+        }
+
+        /// <summary>
+        /// Subscribes to the Tracking Status Changed Event.
+        /// 
+        /// For more info, see 
+        /// <a href="https://github.com/DenchiSoft/VTubeStudio/blob/master/Events/README.md#lostfound-tracking">https://github.com/DenchiSoft/VTubeStudio/blob/master/Events/README.md#lostfound-tracking</a>
+        /// </summary>
+        /// <param name="onEvent">Callback to execute upon receiving an event.</param>
+        /// <param name="onSubscribe">Callback executed upon successfully subscribing to the event.</param>
+        /// <param name="onError">Callback executed upon receiving an error.</param>
+        public void SubscribeToTrackingEvent(Action<VTSTrackingEventData> onEvent, Action<VTSEventSubscriptionResponseData> onSubscribe, Action<VTSErrorData> onError){
+            SubscribeToEvent<VTSTrackingEventSubscriptionRequestData, VTSTrackingEventData>("TrackingStatusChangedEvent", true, new VTSTrackingEventConfigOptions(), onEvent, onSubscribe, onError);
+        }
+
+        /// <summary>
+        /// Unsubscribes from the Tracking Status Changed Event.
+        /// </summary>
+        /// <param name="onUnsubscribe">Callback executed upon successfully unsubscribing from the event.</param>
+        /// <param name="onError">Callback executed upon receiving an error.</param>
+        public void UnsubscribeFromTrackingEvent(Action<VTSEventSubscriptionResponseData> onUnsubscribe, Action<VTSErrorData> onError){
+            SubscribeToEvent<VTSTrackingEventSubscriptionRequestData, VTSTrackingEventData>("TrackingStatusChangedEvent", false, null, DoNothingCallback, onUnsubscribe, onError);
+        }
+
+        /// <summary>
+        /// Subscribes to the Background Changed Event.
+        /// 
+        /// For more info, see 
+        /// <a href="https://github.com/DenchiSoft/VTubeStudio/blob/master/Events/README.md#lostfound-tracking">https://github.com/DenchiSoft/VTubeStudio/blob/master/Events/README.md#lostfound-tracking</a>
+        /// </summary>
+        /// <param name="onEvent">Callback to execute upon receiving an event.</param>
+        /// <param name="onSubscribe">Callback executed upon successfully subscribing to the event.</param>
+        /// <param name="onError">Callback executed upon receiving an error.</param>
+        public void SubscribeToBackgroundChangedEvent(Action<VTSBackgroundChangedEventData> onEvent, Action<VTSEventSubscriptionResponseData> onSubscribe, Action<VTSErrorData> onError){
+            SubscribeToEvent<VTSBackgroundChangedEventSubscriptionRequestData, VTSBackgroundChangedEventData>("BackgroundChangedEvent", true, new VTSBackgroundChangedEventConfigOptions(), onEvent, onSubscribe, onError);
+        }
+
+        /// <summary>
+        /// Unsubscribes from the Background Changed Event.
+        /// </summary>
+        /// <param name="onUnsubscribe">Callback executed upon successfully unsubscribing from the event.</param>
+        /// <param name="onError">Callback executed upon receiving an error.</param>
+        public void UnsubscribeFromBackgroundChangedEvent(Action<VTSEventSubscriptionResponseData> onUnsubscribe, Action<VTSErrorData> onError){
+            SubscribeToEvent<VTSBackgroundChangedEventSubscriptionRequestData, VTSBackgroundChangedEventData>("BackgroundChangedEvent", false, null, DoNothingCallback, onUnsubscribe, onError);
+        }
+
+        /// <summary>
+        /// Subscribes to the Model Config Changed Event.
+        /// 
+        /// For more info, see 
+        /// <a href="https://github.com/DenchiSoft/VTubeStudio/blob/master/Events/README.md#model-config-modified">https://github.com/DenchiSoft/VTubeStudio/blob/master/Events/README.md#model-config-modified</a>
+        /// </summary>
+        /// <param name="onEvent">Callback to execute upon receiving an event.</param>
+        /// <param name="onSubscribe">Callback executed upon successfully subscribing to the event.</param>
+        /// <param name="onError">Callback executed upon receiving an error.</param>
+        public void SubscribeToModelConfigChangedEvent(Action<VTSModelConfigChangedEventData> onEvent, Action<VTSEventSubscriptionResponseData> onSubscribe, Action<VTSErrorData> onError){
+            SubscribeToEvent<VTSModelConfigChangedEventSubscriptionRequestData, VTSModelConfigChangedEventData>("ModelConfigChangedEvent", true, new VTSBackgroundChangedEventConfigOptions(), onEvent, onSubscribe, onError);
+        }
+
+        /// <summary>
+        /// Unsubscribes from the Model Config Changed Event.
+        /// </summary>
+        /// <param name="onUnsubscribe">Callback executed upon successfully unsubscribing from the event.</param>
+        /// <param name="onError">Callback executed upon receiving an error.</param>
+        public void UnsubscribeFromModelConfigChangedEvent(Action<VTSEventSubscriptionResponseData> onUnsubscribe, Action<VTSErrorData> onError){
+            SubscribeToEvent<VTSModelConfigChangedEventSubscriptionRequestData, VTSModelConfigChangedEventData>("ModelConfigChangedEvent", false, null, DoNothingCallback, onUnsubscribe, onError);
+        }
+
+        /// <summary>
+        /// Subscribes to the Model Moved Event.
+        /// 
+        /// For more info, see 
+        /// <a href="https://github.com/DenchiSoft/VTubeStudio/blob/master/Events/README.md#model-movedresizedrotated">https://github.com/DenchiSoft/VTubeStudio/blob/master/Events/README.md#model-movedresizedrotated</a>
+        /// </summary>
+        /// <param name="onEvent">Callback to execute upon receiving an event.</param>
+        /// <param name="onSubscribe">Callback executed upon successfully subscribing to the event.</param>
+        /// <param name="onError">Callback executed upon receiving an error.</param>
+        public void SubscribeToModelMovedEvent(Action<VTSModelMovedEventData> onEvent, Action<VTSEventSubscriptionResponseData> onSubscribe, Action<VTSErrorData> onError){
+            SubscribeToEvent<VTSModelMovedEventSubscriptionRequestData, VTSModelMovedEventData>("ModelMovedEvent", true, new VTSBackgroundChangedEventConfigOptions(), onEvent, onSubscribe, onError);
+        }
+
+        /// <summary>
+        /// Unsubscribes from the Model Moved Event.
+        /// </summary>
+        /// <param name="onUnsubscribe">Callback executed upon successfully unsubscribing from the event.</param>
+        /// <param name="onError">Callback executed upon receiving an error.</param>
+        public void UnsubscribeFromModelMovedEvent(Action<VTSEventSubscriptionResponseData> onUnsubscribe, Action<VTSErrorData> onError){
+            SubscribeToEvent<VTSModelMovedEventSubscriptionRequestData, VTSModelMovedEventData>("ModelMovedEvent", false, null, DoNothingCallback, onUnsubscribe, onError);
+        }        
+
+        /// <summary>
+        /// Subscribes to the Model Outline Event.
+        /// 
+        /// For more info, see 
+        /// <a href="https://github.com/DenchiSoft/VTubeStudio/blob/master/Events/README.md#model-outline-changed">https://github.com/DenchiSoft/VTubeStudio/blob/master/Events/README.md#model-outline-changed</a>
+        /// </summary>
+        /// <param name="config">Configuration options about the subscription.</param>
+        /// <param name="onEvent">Callback to execute upon receiving an event.</param>
+        /// <param name="onSubscribe">Callback executed upon successfully subscribing to the event.</param>
+        /// <param name="onError">Callback executed upon receiving an error.</param>
+        public void SubscribeToModelOutlineEvent(VTSModelOutlineEventConfigOptions config, Action<VTSModelOutlineEventData> onEvent, Action<VTSEventSubscriptionResponseData> onSubscribe, Action<VTSErrorData> onError){
+            SubscribeToEvent<VTSModelOutlineEventSubscriptionRequestData, VTSModelOutlineEventData>("ModelOutlineEvent", true,config, onEvent, onSubscribe, onError);
+        }
+
+        /// <summary>
+        /// Unsubscribes from the Model Outline Event.
+        /// </summary>
+        /// <param name="onUnsubscribe">Callback executed upon successfully unsubscribing from the event.</param>
+        /// <param name="onError">Callback executed upon receiving an error.</param>
+        public void UnsubscribeFromModelOutlineEvent(Action<VTSEventSubscriptionResponseData> onUnsubscribe, Action<VTSErrorData> onError){
+            SubscribeToEvent<VTSModelOutlineEventSubscriptionRequestData, VTSModelOutlineEventData>("ModelOutlineEvent", false, null, DoNothingCallback, onUnsubscribe, onError);
+        }  
 
         #endregion
 
         #region Helper Methods
 
+        /// <summary>
+        /// Static VTS API callback method which does nothing. Saves you from needing to make a new inline function each time.
+        /// </summary>
+        /// <param name="response"></param>
+        protected static void DoNothingCallback(VTSMessageData response){
+            // Do nothing!
+        }
+
         private static Regex ALPHANUMERIC = new Regex(@"\W|");
-        private string SanitizeParameterName(string name){
+        private static string SanitizeParameterName(string name){
             // between 4 and 32 chars, alphanumeric, underscores allowed
             string output = name;
             output = ALPHANUMERIC.Replace(output, "");
@@ -530,7 +958,7 @@ namespace VTS {
 
         }
 
-        private string EncodeIcon(Texture2D icon){
+        private static string EncodeIcon(Texture2D icon){
             try{
                 if(icon.width != 128 && icon.height != 128){
                     Debug.LogWarning("Icon resolution must be exactly 128*128 pixels!");
@@ -543,7 +971,41 @@ namespace VTS {
             return null;
         }
 
+        private static string InjectParameterModeToString(VTSInjectParameterMode mode){
+            if(mode == VTSInjectParameterMode.ADD){
+                return "add";
+            }else if(mode == VTSInjectParameterMode.SET){
+                return "set";
+            }
+            return "set";
+        }
+
+        private static string MotionCurveToString(VTSItemMotionCurve curve){
+            if(curve == VTSItemMotionCurve.LINEAR){
+                return "linear";
+            }else if(curve == VTSItemMotionCurve.EASE_IN){
+                return "easeIn";
+            }else if(curve == VTSItemMotionCurve.EASE_OUT){
+                return "easeOut";
+            }else if(curve == VTSItemMotionCurve.EASE_BOTH){
+                return "easeBoth";
+            }else if(curve == VTSItemMotionCurve.OVERSHOOT){
+                return "overshoot";
+            }else if(curve == VTSItemMotionCurve.ZIP){
+                return "zip";
+            }
+            return "linear";
+        }
+
+        /// <summary>
+        /// Converts the VTS Pair struct to a Unity Vector2 struct.
+        /// </summary>
+        /// <param name="pair">The Pair to convert</param>
+        /// <returns></returns>
+        public static Vector2 PairToVector2(Pair pair){
+            return new Vector2(pair.x, pair.y);
+        }
+
         #endregion
-        
     }
 }

--- a/Assets/Core/VTS/VTSPlugin.cs
+++ b/Assets/Core/VTS/VTSPlugin.cs
@@ -40,7 +40,11 @@ namespace VTS {
         /// The underlying WebSocket for connecting to VTS.
         /// </summary>
         /// <value></value>
-        protected VTSWebSocket Socket { get { return this._socket; } }
+        protected VTSWebSocket Socket { get { 
+            if(this._socket == null){
+                this._socket = GetComponent<VTSWebSocket>();
+            }
+            return this._socket; } }
 
         private string _token = null;
 
@@ -73,47 +77,12 @@ namespace VTS {
         /// <param name="onError">The Callback executed upon failed initialization.</param>
         public void Initialize(IWebSocket webSocket, IJsonUtility jsonUtility, ITokenStorage tokenStorage, Action onConnect, Action onDisconnect, Action onError){
             this._tokenStorage = tokenStorage;
-            this._socket = GetComponent<VTSWebSocket>();
-            // VTSWebSocket.OnPortDiscovered += 
-            this._socket.Initialize(webSocket, jsonUtility);
+            this.Socket.Initialize(webSocket, jsonUtility);
             Action onCombinedConnect = () => {
-                this._socket.ResubscribeToEvents();
+                this.Socket.ResubscribeToEvents();
                 onConnect();
             };
-            this._socket.Connect(() => {
-                // If API enabled, authenticate
-                Authenticate(
-                    (r) => { 
-                        if(!r.data.authenticated){
-                            Reauthenticate(onCombinedConnect, onError);
-                        }else{
-                            this._isAuthenticated = true;
-                            onCombinedConnect();
-                        }
-                    }, 
-                    (r) => { 
-                        // If initial authentication fails, try again
-                        // (Likely just needs fresh token)
-                        Reauthenticate(onCombinedConnect, onError); 
-                    }
-                );
-            },
-            () => {
-                this._isAuthenticated = false;
-                onDisconnect();
-            },
-            () => {
-                this._isAuthenticated = false;
-                onError();
-            });
-        }
-
-        private void OnPortCallback(VTSStateBroadcastData port, Action onConnect, Action onDisconnect, Action onError){
-            Action onCombinedConnect = () => {
-                this._socket.ResubscribeToEvents();
-                onConnect();
-            };
-            this._socket.Connect(() => {
+            this.Socket.Connect(() => {
                 // If API enabled, authenticate
                 Authenticate(
                     (r) => { 
@@ -145,8 +114,8 @@ namespace VTS {
         /// Disconnects from VTube Studio. Will fire the onDisconnect callback set via the Initialize method.
         /// </summary>
         public void Disconnect(){
-            if(this._socket != null){
-                this._socket.Disconnect();
+            if(this.Socket != null){
+                this.Socket.Disconnect();
             }
         }
 
@@ -189,7 +158,7 @@ namespace VTS {
             tokenRequest.data.pluginName = this._pluginName;
             tokenRequest.data.pluginDeveloper = this._pluginAuthor;
             tokenRequest.data.pluginIcon = EncodeIcon(this._pluginIcon);
-            this._socket.Send<VTSAuthData, VTSAuthData>(tokenRequest,
+            this.Socket.Send<VTSAuthData, VTSAuthData>(tokenRequest,
             (a) => {
                 this._token = a.data.authenticationToken; 
                 if(this._tokenStorage != null){
@@ -206,7 +175,7 @@ namespace VTS {
             authRequest.data.pluginName = this._pluginName;
             authRequest.data.pluginDeveloper = this._pluginAuthor;
             authRequest.data.authenticationToken = this._token;
-            this._socket.Send<VTSAuthData, VTSAuthData>(authRequest, onSuccess, onError);
+            this.Socket.Send<VTSAuthData, VTSAuthData>(authRequest, onSuccess, onError);
         }
 
         #endregion
@@ -221,7 +190,15 @@ namespace VTS {
         /// </summary>
         /// <returns>Dictionary indexed by port number.</returns>
         public Dictionary<int, VTSStateBroadcastData> GetPorts(){
-            return this._socket.GetPorts();
+            return this.Socket.GetPorts();
+        }
+
+        /// <summary>
+        /// Gets the current port that this socket is set to connect to.
+        /// </summary>
+        /// <returns>Port number as an int</returns>
+        public int GetPort(){
+            return this.Socket.Port;
         }
 
         /// <summary>
@@ -231,7 +208,7 @@ namespace VTS {
         /// <param name="port">The port to connect to.</param>
         /// <returns>True if the port is a valid VTube Studio port, False otherwise.</returns>
         public bool SetPort(int port){
-            return this._socket.SetPort(port);
+            return this.Socket.SetPort(port);
         }
 
         /// <summary>
@@ -241,7 +218,7 @@ namespace VTS {
         /// <param name="ipString">The string form of the IP address, in dotted-quad notation for IPv4.</param>
         /// <returns>True if the string is a valid IP Address format, False otherwise.</returns>
         public bool SetIPAddress(string ipString){
-            return this._socket.SetIPAddress(ipString);
+            return this.Socket.SetIPAddress(ipString);
         }
 
         #endregion
@@ -258,7 +235,7 @@ namespace VTS {
         /// <param name="onError">Callback executed upon receiving an error.</param>
         public void GetAPIState(Action<VTSStateData> onSuccess, Action<VTSErrorData> onError){
             VTSStateData request = new VTSStateData();
-            this._socket.Send<VTSStateData, VTSStateData>(request, onSuccess, onError);
+            this.Socket.Send<VTSStateData, VTSStateData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -271,7 +248,7 @@ namespace VTS {
         /// <param name="onError">Callback executed upon receiving an error.</param>
         public void GetStatistics(Action<VTSStatisticsData> onSuccess, Action<VTSErrorData> onError){
             VTSStatisticsData request = new VTSStatisticsData();
-            this._socket.Send<VTSStatisticsData, VTSStatisticsData>(request, onSuccess, onError);
+            this.Socket.Send<VTSStatisticsData, VTSStatisticsData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -284,7 +261,7 @@ namespace VTS {
         /// <param name="onError">Callback executed upon receiving an error.</param>
         public void GetFolderInfo(Action<VTSFolderInfoData> onSuccess, Action<VTSErrorData> onError){
             VTSFolderInfoData request = new VTSFolderInfoData();
-            this._socket.Send<VTSFolderInfoData, VTSFolderInfoData>(request, onSuccess, onError);
+            this.Socket.Send<VTSFolderInfoData, VTSFolderInfoData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -297,7 +274,7 @@ namespace VTS {
         /// <param name="onError">Callback executed upon receiving an error.</param>
         public void GetCurrentModel(Action<VTSCurrentModelData> onSuccess, Action<VTSErrorData> onError){
             VTSCurrentModelData request = new VTSCurrentModelData();
-            this._socket.Send<VTSCurrentModelData, VTSCurrentModelData>(request, onSuccess, onError);
+            this.Socket.Send<VTSCurrentModelData, VTSCurrentModelData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -310,7 +287,7 @@ namespace VTS {
         /// <param name="onError">Callback executed upon receiving an error.</param>
         public void GetAvailableModels(Action<VTSAvailableModelsData> onSuccess, Action<VTSErrorData> onError){
             VTSAvailableModelsData request = new VTSAvailableModelsData();
-            this._socket.Send<VTSAvailableModelsData, VTSAvailableModelsData>(request, onSuccess, onError);
+            this.Socket.Send<VTSAvailableModelsData, VTSAvailableModelsData>(request, onSuccess, onError);
         }
         
         /// <summary>
@@ -325,7 +302,7 @@ namespace VTS {
         public void LoadModel(string modelID, Action<VTSModelLoadData> onSuccess, Action<VTSErrorData> onError){
             VTSModelLoadData request = new VTSModelLoadData();
             request.data.modelID = modelID;
-            this._socket.Send<VTSModelLoadData, VTSModelLoadData>(request, onSuccess, onError);
+            this.Socket.Send<VTSModelLoadData, VTSModelLoadData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -340,7 +317,7 @@ namespace VTS {
         public void MoveModel(VTSMoveModelData.Data position, Action<VTSMoveModelData> onSuccess, Action<VTSErrorData> onError){
             VTSMoveModelData request = new VTSMoveModelData();
             request.data = position;
-            this._socket.Send<VTSMoveModelData, VTSMoveModelData>(request, onSuccess, onError);
+            this.Socket.Send<VTSMoveModelData, VTSMoveModelData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -355,7 +332,7 @@ namespace VTS {
         public void GetHotkeysInCurrentModel(string modelID, Action<VTSHotkeysInCurrentModelData> onSuccess, Action<VTSErrorData> onError){
             VTSHotkeysInCurrentModelData request = new VTSHotkeysInCurrentModelData();
             request.data.modelID = modelID;
-            this._socket.Send<VTSHotkeysInCurrentModelData, VTSHotkeysInCurrentModelData>(request, onSuccess, onError);
+            this.Socket.Send<VTSHotkeysInCurrentModelData, VTSHotkeysInCurrentModelData>(request, onSuccess, onError);
         }
         
         /// <summary>
@@ -370,7 +347,7 @@ namespace VTS {
         public void GetHotkeysInLive2DItem(string live2DItemFileName, Action<VTSHotkeysInCurrentModelData> onSuccess, Action<VTSErrorData> onError){
             VTSHotkeysInCurrentModelData request = new VTSHotkeysInCurrentModelData();
             request.data.live2DItemFileName = live2DItemFileName;
-            this._socket.Send<VTSHotkeysInCurrentModelData, VTSHotkeysInCurrentModelData>(request, onSuccess, onError);
+            this.Socket.Send<VTSHotkeysInCurrentModelData, VTSHotkeysInCurrentModelData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -385,7 +362,7 @@ namespace VTS {
         public void TriggerHotkey(string hotkeyID, Action<VTSHotkeyTriggerData> onSuccess, Action<VTSErrorData> onError){
             VTSHotkeyTriggerData request = new VTSHotkeyTriggerData();
             request.data.hotkeyID = hotkeyID;
-            this._socket.Send<VTSHotkeyTriggerData, VTSHotkeyTriggerData>(request, onSuccess, onError);
+            this.Socket.Send<VTSHotkeyTriggerData, VTSHotkeyTriggerData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -402,7 +379,7 @@ namespace VTS {
             VTSHotkeyTriggerData request = new VTSHotkeyTriggerData();
             request.data.hotkeyID = hotkeyID;
             request.data.itemInstanceID = itemInstanceID;
-            this._socket.Send<VTSHotkeyTriggerData, VTSHotkeyTriggerData>(request, onSuccess, onError);
+            this.Socket.Send<VTSHotkeyTriggerData, VTSHotkeyTriggerData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -415,7 +392,7 @@ namespace VTS {
         /// <param name="onError">Callback executed upon receiving an error.</param>
         public void GetArtMeshList(Action<VTSArtMeshListData> onSuccess, Action<VTSErrorData> onError){
             VTSArtMeshListData request = new VTSArtMeshListData();
-            this._socket.Send<VTSArtMeshListData, VTSArtMeshListData>(request, onSuccess, onError);
+            this.Socket.Send<VTSArtMeshListData, VTSArtMeshListData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -436,7 +413,7 @@ namespace VTS {
             colorTint.mixWithSceneLightingColor = System.Math.Min(1, System.Math.Max(mixWithSceneLightingColor, 0));
             request.data.colorTint = colorTint;
             request.data.artMeshMatcher = matcher;
-            this._socket.Send<VTSColorTintData, VTSColorTintData>(request, onSuccess, onError);
+            this.Socket.Send<VTSColorTintData, VTSColorTintData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -449,7 +426,7 @@ namespace VTS {
         /// <param name="onError"></param>
         public void GetSceneColorOverlayInfo(Action<VTSSceneColorOverlayData> onSuccess, Action<VTSErrorData> onError){
             VTSSceneColorOverlayData request = new VTSSceneColorOverlayData();
-            this._socket.Send<VTSSceneColorOverlayData, VTSSceneColorOverlayData>(request, onSuccess, onError);
+            this.Socket.Send<VTSSceneColorOverlayData, VTSSceneColorOverlayData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -462,7 +439,7 @@ namespace VTS {
         /// <param name="onError">Callback executed upon receiving an error.</param>
         public void GetFaceFound(Action<VTSFaceFoundData> onSuccess, Action<VTSErrorData> onError){
             VTSFaceFoundData request = new VTSFaceFoundData();
-            this._socket.Send<VTSFaceFoundData, VTSFaceFoundData>(request, onSuccess, onError);
+            this.Socket.Send<VTSFaceFoundData, VTSFaceFoundData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -475,7 +452,7 @@ namespace VTS {
         /// <param name="onError">Callback executed upon receiving an error.</param>
         public void GetInputParameterList(Action<VTSInputParameterListData> onSuccess, Action<VTSErrorData> onError){
             VTSInputParameterListData request = new VTSInputParameterListData();
-            this._socket.Send<VTSInputParameterListData, VTSInputParameterListData>(request, onSuccess, onError);
+            this.Socket.Send<VTSInputParameterListData, VTSInputParameterListData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -490,7 +467,7 @@ namespace VTS {
         public void GetParameterValue(string parameterName, Action<VTSParameterValueData> onSuccess, Action<VTSErrorData> onError){
             VTSParameterValueData request = new VTSParameterValueData();
             request.data.name = parameterName;
-            this._socket.Send<VTSParameterValueData, VTSParameterValueData>(request, onSuccess, onError);
+            this.Socket.Send<VTSParameterValueData, VTSParameterValueData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -503,7 +480,7 @@ namespace VTS {
         /// <param name="onError">Callback executed upon receiving an error.</param>
         public void GetLive2DParameterList(Action<VTSLive2DParameterListData> onSuccess, Action<VTSErrorData> onError){
             VTSLive2DParameterListData request = new VTSLive2DParameterListData();
-            this._socket.Send<VTSLive2DParameterListData, VTSLive2DParameterListData>(request, onSuccess, onError);
+            this.Socket.Send<VTSLive2DParameterListData, VTSLive2DParameterListData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -522,7 +499,7 @@ namespace VTS {
             request.data.min = parameter.min;
             request.data.max = parameter.max;
             request.data.defaultValue = parameter.defaultValue;
-            this._socket.Send<VTSParameterCreationData, VTSParameterCreationData>(request, onSuccess, onError);
+            this.Socket.Send<VTSParameterCreationData, VTSParameterCreationData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -537,7 +514,7 @@ namespace VTS {
         public void RemoveCustomParameter(string parameterName, Action<VTSParameterDeletionData> onSuccess, Action<VTSErrorData> onError){
             VTSParameterDeletionData request = new VTSParameterDeletionData();
             request.data.parameterName = SanitizeParameterName(parameterName);
-            this._socket.Send<VTSParameterDeletionData, VTSParameterDeletionData>(request, onSuccess, onError);
+            this.Socket.Send<VTSParameterDeletionData, VTSParameterDeletionData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -586,7 +563,7 @@ namespace VTS {
             request.data.faceFound = faceFound;
             request.data.parameterValues = values;
             request.data.mode = InjectParameterModeToString(mode);
-            this._socket.Send<VTSInjectParameterData, VTSInjectParameterData>(request, onSuccess, onError);
+            this.Socket.Send<VTSInjectParameterData, VTSInjectParameterData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -600,7 +577,7 @@ namespace VTS {
         public void GetExpressionStateList(Action<VTSExpressionStateData> onSuccess, Action<VTSErrorData> onError){
             VTSExpressionStateData request = new VTSExpressionStateData();
             request.data.details = true;
-            this._socket.Send<VTSExpressionStateData, VTSExpressionStateData>(request, onSuccess, onError);
+            this.Socket.Send<VTSExpressionStateData, VTSExpressionStateData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -617,7 +594,7 @@ namespace VTS {
             VTSExpressionActivationData request = new VTSExpressionActivationData();
             request.data.expressionFile = expression;
             request.data.active = active;
-            this._socket.Send<VTSExpressionActivationData, VTSExpressionActivationData>(request, onSuccess, onError);
+            this.Socket.Send<VTSExpressionActivationData, VTSExpressionActivationData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -630,7 +607,7 @@ namespace VTS {
         /// <param name="onError">Callback executed upon receiving an error.</param>
         public void GetCurrentModelPhysics(Action<VTSCurrentModelPhysicsData> onSuccess, Action<VTSErrorData> onError){
             VTSCurrentModelPhysicsData request = new VTSCurrentModelPhysicsData();
-            this._socket.Send<VTSCurrentModelPhysicsData, VTSCurrentModelPhysicsData>(request, onSuccess, onError);
+            this.Socket.Send<VTSCurrentModelPhysicsData, VTSCurrentModelPhysicsData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -647,7 +624,7 @@ namespace VTS {
             VTSOverrideModelPhysicsData request = new VTSOverrideModelPhysicsData();
             request.data.strengthOverrides = strengthOverrides;
             request.data.windOverrides = windOverrides;
-            this._socket.Send<VTSOverrideModelPhysicsData, VTSOverrideModelPhysicsData>(request, onSuccess, onError);
+            this.Socket.Send<VTSOverrideModelPhysicsData, VTSOverrideModelPhysicsData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -660,7 +637,7 @@ namespace VTS {
         /// <param name="onSuccess">Callback executed upon receiving a response.</param>
         /// <param name="onError">Callback executed upon receiving an error.</param>
         public void SetNDIConfig(VTSNDIConfigData config, Action<VTSNDIConfigData> onSuccess, Action<VTSErrorData> onError){
-            this._socket.Send<VTSNDIConfigData, VTSNDIConfigData>(config, onSuccess, onError);
+            this.Socket.Send<VTSNDIConfigData, VTSNDIConfigData>(config, onSuccess, onError);
         }
 
         /// <summary>
@@ -679,7 +656,7 @@ namespace VTS {
             request.data.includeAvailableItemFiles = options.includeAvailableItemFiles;
             request.data.onlyItemsWithFileName = options.onlyItemsWithFileName;
             request.data.onlyItemsWithInstanceID = options.onlyItemsWithInstanceID;
-            this._socket.Send<VTSItemListRequestData, VTSItemListResponseData>(request, onSuccess, onError);
+            this.Socket.Send<VTSItemListRequestData, VTSItemListResponseData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -707,7 +684,7 @@ namespace VTS {
             request.data.flipped = options.flipped;
             request.data.locked = options.locked;
             request.data.unloadWhenPluginDisconnects = options.unloadWhenPluginDisconnects;
-            this._socket.Send<VTSItemLoadRequestData, VTSItemLoadResponseData>(request, onSuccess, onError);
+            this.Socket.Send<VTSItemLoadRequestData, VTSItemLoadResponseData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -726,7 +703,7 @@ namespace VTS {
             request.data.unloadAllInScene = options.unloadAllInScene;
             request.data.unloadAllLoadedByThisPlugin = options.unloadAllLoadedByThisPlugin;
             request.data.allowUnloadingItemsLoadedByUserOrOtherPlugins = options.allowUnloadingItemsLoadedByUserOrOtherPlugins;
-            this._socket.Send<VTSItemUnloadRequestData, VTSItemUnloadResponseData>(request, onSuccess, onError);
+            this.Socket.Send<VTSItemUnloadRequestData, VTSItemUnloadResponseData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -749,7 +726,7 @@ namespace VTS {
             request.data.autoStopFrames = options.autoStopFrames;
             request.data.setAnimationPlayState = options.setAnimationPlayState;
             request.data.animationPlayState = options.animationPlayState;
-            this._socket.Send<VTSItemAnimationControlRequestData, VTSItemAnimationControlResponseData>(request, onSuccess, onError);
+            this.Socket.Send<VTSItemAnimationControlRequestData, VTSItemAnimationControlResponseData>(request, onSuccess, onError);
         }
 
         /// <summary>
@@ -780,7 +757,7 @@ namespace VTS {
                     entry.options.userCanStop
                 );
             }
-            this._socket.Send<VTSItemMoveRequestData, VTSItemMoveResponseData>(request, onSuccess, onError);
+            this.Socket.Send<VTSItemMoveRequestData, VTSItemMoveResponseData>(request, onSuccess, onError);
         }
 
         public void RequestArtMeshSelection(string textOverride, string helpOverride, int count, 
@@ -794,7 +771,7 @@ namespace VTS {
             activeArtMeshes.CopyTo(array, 0);
             request.data.activeArtMeshes = array;
 
-            this._socket.Send<VTSArtMeshSelectionRequestData, VTSArtMeshSelectionResponseData>(request, onSuccess, onError);
+            this.Socket.Send<VTSArtMeshSelectionRequestData, VTSArtMeshSelectionResponseData>(request, onSuccess, onError);
         }
 
         #endregion
@@ -808,7 +785,7 @@ namespace VTS {
             if(config != null){
                 request.SetConfig(config);
             }
-            this._socket.SendEventSubscription<T, K>(request, onEvent, onSubscribe, onError, () => {
+            this.Socket.SendEventSubscription<T, K>(request, onEvent, onSubscribe, onError, () => {
                 SubscribeToEvent<T, K>(eventName, subscribed, config, onEvent, onSubscribe, onError);
             });
         }

--- a/Assets/Localization/Scripts/LocalizationManager.cs
+++ b/Assets/Localization/Scripts/LocalizationManager.cs
@@ -4,8 +4,7 @@ using System.Text.RegularExpressions;
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Localization
-{
+namespace Localization {
     public class LocalizationManager : Singleton<LocalizationManager> {
 
         [Header("Strings")]
@@ -32,8 +31,7 @@ namespace Localization
         private List<Dictionary<string, string>> _loadedStrings;
 
         private int _languageIndex = 0;
-        public SupportedLanguage CurrentLanguage
-        {
+        public SupportedLanguage CurrentLanguage{
             get { return (SupportedLanguage)(_languageIndex + 1);}
         }
 
@@ -46,15 +44,17 @@ namespace Localization
         private bool _initialized = false;
 
         // Use this for initialization
-        public override void Initialize()
-        {
-            if(!_initialized)
-            {
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSplashScreen)]
+        private static void OnBoot(){
+            // TODO: Can we load strings in here, somehow?
+        }
+
+        public override void Initialize(){
+            if(!_initialized){
+                // refresh
                 _loadedStrings = new List<Dictionary<string, string>>();
                 ParseTable(_stringTable);
                 _initialized = true;
-                // refresh
-
                 // We can either initialize by choosing the first language, 
                 // or by choosing the system language
                 //SwitchLanguage(_languageIndex);
@@ -62,27 +62,21 @@ namespace Localization
             }
         }
 
-        public static void RegisterLocalizedText(LocalizedText text)
-        {
-            if(!_localizedTexts.Contains(text))
-            {
+        public static void RegisterLocalizedText(LocalizedText text){
+            if(!_localizedTexts.Contains(text)){
                 _localizedTexts.Add(text);
             }
         }
 
-        public static void UnregisterLocalizedText(LocalizedText text)
-        {
-            if(_localizedTexts.Contains(text))
-            {
+        public static void UnregisterLocalizedText(LocalizedText text){
+            if(_localizedTexts.Contains(text)){
                 _localizedTexts.Remove(text);
             }
         }
 
         public void RefreshAllLocalizedText(){
-            foreach(LocalizedText t in _localizedTexts)
-            {
-                if(t.gameObject.activeInHierarchy)
-                {
+            foreach(LocalizedText t in _localizedTexts){
+                if(t.gameObject.activeInHierarchy){
                     t.Localize();
                 }
             }
@@ -92,8 +86,7 @@ namespace Localization
         /// Switch the language to a different language index
         /// </summary>
         /// <param name="language">The numeric index in the list of languages</param>
-        private void SwitchLanguage(int language)
-        {
+        private void SwitchLanguage(int language){
             _languageIndex = language;
             RefreshAllLocalizedText();
         }
@@ -102,8 +95,7 @@ namespace Localization
         /// Switch the language to a different language index
         /// </summary>
         /// <param name="language">The specific supported language</param>
-        public void SwitchLanguage(SupportedLanguage language)
-        {
+        public void SwitchLanguage(SupportedLanguage language){
             SwitchLanguage(((int)language) - 1);
         }
 
@@ -132,11 +124,9 @@ namespace Localization
         /// Defaults to English if no match can be found
         /// </summary>
         /// <param name="sysLanguage"></param>
-        private void SwitchToSystemLanguage(SystemLanguage sysLanguage)
-        {
+        private void SwitchToSystemLanguage(SystemLanguage sysLanguage){
             SupportedLanguage lang = SupportedLanguage.ENGLISH;
-            switch(sysLanguage)
-            {
+            switch(sysLanguage){
                 case SystemLanguage.English:
                     lang = SupportedLanguage.ENGLISH;
                     break;
@@ -168,8 +158,7 @@ namespace Localization
         /// Is the current language a right-to-left language, such as Arabic?
         /// </summary>
         /// <returns></returns>
-        public bool IsRightToLeft()
-        {
+        public bool IsRightToLeft(){
             return false;
             //return CurrentLanguage == (SupportedLanguage.ARABIC);
         }
@@ -183,18 +172,14 @@ namespace Localization
         /// </summary>
         /// <param name="strings"></param>
         /// <param name="language"></param>
-        public void AddStrings(Dictionary<string, string> strings, SupportedLanguage language)
-        {
-            foreach(string key in strings.Keys)
-            {
+        public void AddStrings(Dictionary<string, string> strings, SupportedLanguage language){
+            foreach(string key in strings.Keys){
                 if(strings[key] != null){
-                    if (_loadedStrings[(int)(language-1)].ContainsKey(key))
-                    {
+                    if (_loadedStrings[(int)(language-1)].ContainsKey(key)){
 
                         _loadedStrings[(int)(language-1)][key] = strings[key];
                     }
-                    else
-                    {
+                    else{
                         _loadedStrings[(int)(language-1)].Add(key, strings[key]);
                     }
                 }
@@ -208,8 +193,7 @@ namespace Localization
         /// </summary>
         /// <param name="strings"></param>
         /// <param name="language"></param>
-        public void LoadStringTable(TextAsset stringTable)
-        {
+        public void LoadStringTable(TextAsset stringTable){
             ParseTable(stringTable);
         }
 
@@ -218,8 +202,7 @@ namespace Localization
         /// </summary>
         /// <param name="key">The key to look up</param>
         /// <returns></returns>
-        public string GetString(string key)
-        {
+        public string GetString(string key){
             return GetString(key, _languageIndex);
         }
 
@@ -229,8 +212,7 @@ namespace Localization
         /// <param name="key">The key to look up</param>
         /// <param name="language">The language to reference</param>
         /// <returns></returns>
-        public string GetString(string key, SupportedLanguage language)
-        {
+        public string GetString(string key, SupportedLanguage language){
             return GetString(key, ((int)language) - 1);
         }
 
@@ -240,21 +222,17 @@ namespace Localization
         /// <param name="key">The key to look up</param>
         /// <param name="language">The language to reference</param>
         /// <returns></returns>
-        private string GetString(string key, int language)
-        {
+        private string GetString(string key, int language){
             string value = DUMMY_STRING;
             key = key.ToLower();
-            if (_loadedStrings != null && _loadedStrings.Count > language && _loadedStrings[language].ContainsKey(key))
-            {
+            if (_loadedStrings != null && _loadedStrings.Count > language && _loadedStrings[language].ContainsKey(key)){
                 value = _loadedStrings[language][key];
                 value = RecursiveReplace(value, 0, language, 0);
             }
-            else
-            {
+            else{
                 Debug.LogWarning("String not found in table for key: " + key);
             }
-            if(IsRightToLeft())
-            {
+            if(IsRightToLeft()){
                 // here, you can insert your own method of doing RTL text cleanup.
                 // I'd recommend using https://github.com/Konash/arabic-support-unity 
                 // big thanks to Open Source code from Abdullah Konash!
@@ -271,8 +249,7 @@ namespace Localization
         /// </summary>
         /// <param name="key">The key to check for</param>
         /// <returns></returns>
-        public bool ContainsKey(string key)
-        {
+        public bool ContainsKey(string key){
             return _loadedStrings != null && _loadedStrings.Count > _languageIndex && _loadedStrings[_languageIndex].ContainsKey(key);
         }
 
@@ -288,70 +265,55 @@ namespace Localization
         /// <param name="languageIndex">Which language to do replacement from</param>
         /// <param name="cycleCount">How many levels deep we should try to replace before aborting</param>
         /// <returns></returns>
-        private string RecursiveReplace(string toModify, int startIndex, int languageIndex, int cycleCount)
-        {
+        private string RecursiveReplace(string toModify, int startIndex, int languageIndex, int cycleCount){
             string modifySubstring = toModify.Substring(startIndex);
-            if (cycleCount < REPLACEMENT_CYCLE_MAX && modifySubstring.Contains(REPLACEMENT_KEY_TAG.ToString()) && startIndex < toModify.Length)
-            {
+            if (cycleCount < REPLACEMENT_CYCLE_MAX && modifySubstring.Contains(REPLACEMENT_KEY_TAG.ToString()) && startIndex < toModify.Length){
                 string keySubstring = modifySubstring.Substring(modifySubstring.IndexOf(REPLACEMENT_KEY_TAG) + 1);
                 int punctuationIndex = GetIndexOfPunctuation(keySubstring);
                 int endIndex = (punctuationIndex > 0) ? Mathf.Min(punctuationIndex, keySubstring.Length) : keySubstring.Length;
                 keySubstring = keySubstring.Substring(0, endIndex);
-                if (_loadedStrings[languageIndex].ContainsKey(keySubstring.ToLower()))
-                {
+                if (_loadedStrings[languageIndex].ContainsKey(keySubstring.ToLower())){
                     toModify = toModify.Replace(REPLACEMENT_KEY_TAG + keySubstring, GetString(keySubstring, languageIndex));
                 }
                 cycleCount++;
                 return RecursiveReplace(toModify, startIndex + 1, languageIndex, cycleCount);
             }
-            else
-            {
+            else{
                 return toModify;
             }
         }
 
-        private void ReadLine(int lineIndex, List<string> line)
-        {
+        private void ReadLine(int lineIndex, List<string> line){
             line[0] = line[0].Trim().ToLower();
-            if (line[0] != "")
-            {
+            if (line[0] != ""){
                 if(GetIndexOfPunctuation(line[0]) == -1){
-                    for (int i = 1; i < line.Count; i++)
-                    {
-                        if (_loadedStrings.Count < i)
-                        {
+                    for (int i = 1; i < line.Count; i++){
+                        if (_loadedStrings.Count < i){
                             _loadedStrings.Add(new Dictionary<string, string>());
                         }
-                        if (line[i].Trim() != "")
-                        {
-                            try 
-                            {
+                        if (line[i].Trim() != ""){
+                            try {
                                 line[i] = line[i].Replace("\\n", "\n");
-                                if(_loadedStrings[i - 1].ContainsKey(line[0]))
-                                {
+                                if(_loadedStrings[i - 1].ContainsKey(line[0])){
                                     _loadedStrings[i - 1][line[0]] = line[i];
                                 }
-                                else
-                                {
+                                else{
                                     _loadedStrings[i - 1].Add(line[0], line[i]);
                                 }
                             }
-                            catch (Exception e)
-                            {
+                            catch (Exception e){
                                 Debug.LogWarning(e.Message + "\n" + line[0] + "\n" + line[i]);
                             }
                         }
                     }
                 }
-                else
-                {
+                else{
                     Debug.LogWarning("Key: " + line[0] + " contains disallowed punctuation!");
                 }
             }
         }
 
-        private void ParseTable(TextAsset stringTable)
-        {
+        private void ParseTable(TextAsset stringTable){
             string tableContent = stringTable.text;
             int tableLength = tableContent.Length;
             // read char by char and when a , or \n, perform appropriate action
@@ -361,32 +323,25 @@ namespace Localization
             StringBuilder currentItem = new StringBuilder();
             bool inQuotes = false; // managing quotes
             char currentChar;
-            while (currentCharIndex < tableLength)
-            {
+            while (currentCharIndex < tableLength){
                 currentChar = tableContent[currentCharIndex++];
-                switch (currentChar)
-                {
+                switch (currentChar){
                     case '"':
-                        if (!inQuotes)
-                        {
+                        if (!inQuotes){
                             inQuotes = true;
                         }
-                        else
-                        {
-                            if (currentCharIndex == tableLength)
-                            {
+                        else{
+                            if (currentCharIndex == tableLength){
                                 // end of file
                                 inQuotes = false;
                                 goto case '\n';
                             }
-                            else if (tableContent[currentCharIndex] == '"')
-                            {
+                            else if (tableContent[currentCharIndex] == '"'){
                                 // double quote, save one
                                 currentItem.Append("\"");
                                 currentCharIndex++;
                             }
-                            else
-                            {
+                            else{
                                 // leaving quotes section
                                 inQuotes = false;
                             }
@@ -398,18 +353,15 @@ namespace Localization
                     case ',':
                         goto case '\n';
                     case '\n':
-                        if (inQuotes)
-                        {
+                        if (inQuotes){
                             // inside quotes, this characters must be included
                             currentItem.Append(currentChar);
                         }
-                        else
-                        {
+                        else{
                             // end of current item
                             currentLine.Add(currentItem.ToString());
                             currentItem.Length = 0;
-                            if (currentChar == '\n' || currentCharIndex == tableLength)
-                            {
+                            if (currentChar == '\n' || currentCharIndex == tableLength){
                                 // also end of line, call line reader
                                 ReadLine(currentLineCount++, currentLine);
                                 currentLine.Clear();
@@ -431,19 +383,14 @@ namespace Localization
         /// </summary>
         /// <param name="input"></param>
         /// <returns></returns>
-        private static int GetIndexOfPunctuation(string input)
-        {
-            if(REGEX_PUNCTUATION_FILTER.IsMatch(input))
-            {
+        private static int GetIndexOfPunctuation(string input){
+            if(REGEX_PUNCTUATION_FILTER.IsMatch(input)){
                 return REGEX_PUNCTUATION_FILTER.Match(input).Index;
             }
-            else
-            {
+            else{
                 return -1;
             }
         }
-
-
     }
 
     /// <summary>
@@ -451,8 +398,7 @@ namespace Localization
     /// 
     /// int value corresponds the column of the language in the source CSV file (therefore 1 indexed, as column 0 is the key list)
     /// </summary>
-    public enum SupportedLanguage : int
-    {
+    public enum SupportedLanguage : int {
         ENGLISH = 1,
         // JAPANESE = 2,
     }

--- a/Assets/Localization/strings.csv
+++ b/Assets/Localization/strings.csv
@@ -33,7 +33,7 @@ settings_api_server_messages_received,Messages received: {0},
 ,,
 settings_api_server_approved_plugin_title,Approved Plugins,
 settings_api_server_approve_plugin_title,Approve this Plugin?,
-settings_api_server_approve_plugin_tooltip,"Do you want to approve  %settings_api_server_input_title access for the plugin named <b>{0}</b>, made by <b>{1}</b>? 
+settings_api_server_approve_plugin_tooltip,"Do you want to approve %settings_api_server_input_title access for the plugin named <b>{0}</b>, made by <b>{1}</b>? 
 
 Doing so will grant the plugin permission to write heartrate data via the <b>%input_websocket_title</b> input.",
 settings_api_server_button_approve,Approve,
@@ -284,11 +284,16 @@ error_cannot_resolve_tooltip,"Communication with the version server, <b>https://
 
 This may result in the <b>inability check for a new version</b> of this plugin, and an <b>inability to receive a new Pulsoid authentication token</b>. Existing authentication tokens should still work.
 
-Please feel free to alert Tom to this issue via one of the contact methods below.",
+Please alert Tom to this issue via one of the contact methods below.",
+error_cannot_subscribe_tooltip,"Connecting to the VTube Studio API has failed with the following error: <i>{0}: {1}</i>.
+
+Please alert Tom to this issue via one of the contact methods below.",
+,,
 ,,
 button_generic_confirm,Confirm,
 button_generic_copy,Copy,コピー
 button_generic_cancel,Cancel,キャンセル
+button_generic_retry,Retry,
 button_generic_load,Load,
 button_generic_delete,Delete,削除
 button_tab_inputs,Inputs,入力

--- a/Assets/Network/WSS/API Test Scripts.js
+++ b/Assets/Network/WSS/API Test Scripts.js
@@ -9,7 +9,11 @@ eventWS.onmessage = (e) => {console.log(JSON.parse(e.data))}
 //Input/Auth
 const inputWS = new WebSocket('ws://localhost:8214/input');
 const reconnect = {}
+inputWS.onerror = (e) => {
+    console.error(e);
+}
 inputWS.onmessage = (e) => {
+    console.log(e);
     const parsed = JSON.parse(e.data);
     console.log(parsed)
     if(!parsed.data.authenticated && parsed.messageType == "AuthenticationResponse"){

--- a/Assets/Network/WSS/APIManager.cs
+++ b/Assets/Network/WSS/APIManager.cs
@@ -290,7 +290,8 @@ public class APIManager : Singleton<APIManager>
             this._path = path;
             this._service = new APIService(path, onOpen, 
             (a, b) => { 
-                onMessage(a, b);                         
+                onMessage(a, b);
+                // Debug.Log(string.Format("Receiving: {0}", a));                         
                 this._messages = this._messages + 1;
             } );
         }
@@ -317,8 +318,9 @@ public class APIManager : Singleton<APIManager>
             WebSocketServiceHost host;
             if(this._server != null 
             && this._server.WebSocketServices.TryGetServiceHost(this._path, out host)){
+                // Debug.Log(string.Format("Sending to ID {0}: {1}", sessionID, message.ToString()));
                 try{
-                    host.Sessions.SendTo(sessionID, message.ToString());
+                    host.Sessions.SendTo(message.ToString(), sessionID);
                     this._messages = this._messages + 1;
                     return true;
                 }catch(System.Exception e){

--- a/Assets/Tools/Logging Manager.prefab
+++ b/Assets/Tools/Logging Manager.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2947723539784729396
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2947723539784729398}
+  - component: {fileID: 2947723539784729397}
+  m_Layer: 0
+  m_Name: Logging Manager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2947723539784729398
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2947723539784729396}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2947723539784729397
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2947723539784729396}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f6dcf567c5099746baf7d2fdd075129, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _initializationOrder: 0

--- a/Assets/Tools/Logging Manager.prefab.meta
+++ b/Assets/Tools/Logging Manager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ae4321cbfba9e1c419cf97ad084e7537
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tools/LoggingManager.cs
+++ b/Assets/Tools/LoggingManager.cs
@@ -1,26 +1,120 @@
-﻿using System.Collections;
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using System.Collections.Concurrent;
 
-public class LoggingManager : Singleton<LoggingManager>
-{
-    private Queue<string> _loggingQueue = new Queue<string>();
-    public override void Initialize()
-    {
-        _loggingQueue = new Queue<string>();
-    }
+public class LoggingManager : Singleton<LoggingManager>{
 
-    public void Log(string log){
-        Debug.Log(log);
-        this._loggingQueue.Enqueue(log);
-    }
+    private static string GLOBAL_LOG_DIRECTORY;
+    public string LogDirectory { get { return GLOBAL_LOG_DIRECTORY; } }
+    private const string LOG_FILE_PREFIX = "log";
+    private const string LOG_FILE_NAME_FORMAT = "{0}_{1}.txt";
+    private static string LOG_FILE_PATH_FULL;
+    private const int MAX_LOG_FILES = 8;
 
-    private void Update(){
-        if(this._loggingQueue.Count > 0){
-            string log = this._loggingQueue.Dequeue();
-            // LogEntry instance = Instantiate<LogEntry>(this._entryPrefab, Vector3.zero, Quaternion.identity, this._logParent);
-            // instance.transform.SetSiblingIndex(0);
-            // instance.Log(log);
+    private static ConcurrentQueue<LogRecord> QUEUE = new ConcurrentQueue<LogRecord>();
+    static ReaderWriterLock LOCKER = new ReaderWriterLock();
+    private static Thread WORKER;
+    private static bool QUITTING = false;
+
+    [System.Serializable]
+    public struct LogRecord {
+        public DateTime time;
+        public LogType type;
+        public string message;
+        public string stack;
+
+        public LogRecord(LogType type, string message, string stack){
+            this.message = message;
+            this.stack = stack;
+            this.type = type;
+            this.time = DateTime.Now;
         }
+
+        public override string ToString(){
+            return string.Format("[{0}] [{1}] - {2}\n", 
+                time.ToString("MM/dd/yyyy HH:mm:ss"), 
+                type, 
+                (type == LogType.Exception || type == LogType.Error) && stack != null && stack.Length > 0 
+                ? string.Format("{0} - {1}", message, stack)
+                : message);
+        }
+    }
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSplashScreen)]
+    public static void OnBoot(){
+        GLOBAL_LOG_DIRECTORY = Path.Combine(Application.persistentDataPath, "logs");
+        if(!Directory.Exists(GLOBAL_LOG_DIRECTORY)){
+            Directory.CreateDirectory(GLOBAL_LOG_DIRECTORY);
+        }
+        string timestamp = DateTime.Now.ToString("MM_dd_yyyy_HH_mm_ss");
+        LOG_FILE_PATH_FULL = Path.Combine(GLOBAL_LOG_DIRECTORY, string.Format(LOG_FILE_NAME_FORMAT, LOG_FILE_PREFIX, timestamp));
+        Application.logMessageReceivedThreaded += EnqueueLog;
+        WORKER = new Thread(PrintToLog);
+        WORKER.Start();
+        DeleteOldLogs();
+    }
+
+    public override void Initialize(){
+    }
+
+    private void OnApplicationQuit(){
+        QUITTING = true;
+    }
+
+    public static void EnqueueLog(string logString, string stackTrace, LogType type){
+        QUEUE.Enqueue(new LogRecord(type, logString, stackTrace));
+    }
+
+    private static void PrintToLog(){
+        do{
+            string joined = "";
+            do{
+                LogRecord log;
+                if(QUEUE.TryDequeue(out log)){
+                    joined += log.ToString();
+                }
+            }while(QUEUE.Count > 0);
+            try{
+                LOCKER.AcquireWriterLock(int.MaxValue); 
+                System.IO.File.AppendAllText(LOG_FILE_PATH_FULL, joined, Encoding.UTF8);
+            }finally{
+                LOCKER.ReleaseWriterLock();
+                joined = string.Empty;
+            }
+            Thread.Sleep(1);
+        }while(QUEUE.Count > 0 || QUITTING == false);
+    }
+
+    /// <summary>
+    /// Deletes old log files.
+    /// </summary>
+    /// <returns>False if failed, true otherwise.</returns>
+    private static bool DeleteOldLogs(){
+        try { 
+            List<string> oldLogFiles = new List<string>(Directory.GetFiles(GLOBAL_LOG_DIRECTORY));
+            List<string> filteredLogFiles = oldLogFiles.FindAll(fileName => fileName.Contains(LOG_FILE_PREFIX));
+            int logFilesToDelete = filteredLogFiles.Count - MAX_LOG_FILES;
+            if (logFilesToDelete > 0){
+                filteredLogFiles.Sort((a, b) => File.GetCreationTime(a).CompareTo(File.GetCreationTime(b)));
+                foreach (string oldLogName in filteredLogFiles){
+                    Debug.Log("Deleting old log file: " + Path.GetFileName(oldLogName));
+                    File.Delete(oldLogName);
+                    logFilesToDelete--;
+                    if (logFilesToDelete <= 0){
+                        break;
+                    }
+                }
+            }
+        }
+        catch (Exception){
+            return false;
+        }
+
+        return true;
     }
 }

--- a/Assets/UI/Scripts/Elements/OpenLogButton.cs
+++ b/Assets/UI/Scripts/Elements/OpenLogButton.cs
@@ -1,6 +1,5 @@
 ﻿using UnityEngine;
 using UI.InputTools;
-using System.IO;
 
 [RequireComponent(typeof(ExtendedButton))]
 public class OpenLogButton : MonoBehaviour
@@ -8,10 +7,9 @@ public class OpenLogButton : MonoBehaviour
     private ExtendedButton _button = null;
 
     // Start is called before the first frame update
-    void Start()
-    {
+    void Start(){
         this._button = GetComponent<ExtendedButton>();
-        this._button.onPointerUp.AddListener(() => {Application.OpenURL(Path.Combine(Application.persistentDataPath, "Player.log"));});
+        this._button.onPointerUp.AddListener(() => { Application.OpenURL(LoggingManager.Instance.LogDirectory); });
     }
 }
 

--- a/Assets/UI/Scripts/Modules/Settings/PortSelector.cs
+++ b/Assets/UI/Scripts/Modules/Settings/PortSelector.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using UnityEngine;
+using System.Collections.Generic;
 
 public class PortSelector : RefreshableDropdown
 {
@@ -13,8 +14,14 @@ public class PortSelector : RefreshableDropdown
         HeartrateManager.Instance.Plugin.Connect();
     }
 
-    public override void Refresh()
-    {
+    public override void Refresh(){
+        int optionCount = this._dropdown.options != null ? this._dropdown.options.Count : 0;
         RefreshValues(HeartrateManager.Instance.Plugin.GetPorts().Keys);
+        int newOptionsCount = this._dropdown.options != null ? this._dropdown.options.Count : 0;
+        if(optionCount == 0 && newOptionsCount > 0){
+            int port = int.Parse(this._dropdown.options[0].text);
+            Debug.Log(string.Format("Setting default port: {0}", port));
+            HeartrateManager.Instance.Plugin.SetPort(port);
+        }
     }
 }

--- a/Assets/UI/Scripts/Modules/Settings/PortSelector.cs
+++ b/Assets/UI/Scripts/Modules/Settings/PortSelector.cs
@@ -1,9 +1,7 @@
 ﻿using UnityEngine;
 using System.Collections.Generic;
 
-public class PortSelector : RefreshableDropdown
-{
-    private List<string> _portNumbers = new List<string>();
+public class PortSelector : RefreshableDropdown {
 
     protected override void Initialize(){
         UIManager.Instance.RegisterEventCallback(UIManager.Tabs.SETTINGS, Refresh);
@@ -12,16 +10,22 @@ public class PortSelector : RefreshableDropdown
     protected override void SetValue(int index){
         HeartrateManager.Instance.Plugin.SetPort(int.Parse(this._dropdown.options[index].text));
         HeartrateManager.Instance.Plugin.Connect();
+        // Set display value to actual port
+        UpdateDisplay();
     }
 
     public override void Refresh(){
-        int optionCount = this._dropdown.options != null ? this._dropdown.options.Count : 0;
-        RefreshValues(HeartrateManager.Instance.Plugin.GetPorts().Keys);
-        int newOptionsCount = this._dropdown.options != null ? this._dropdown.options.Count : 0;
-        if(optionCount == 0 && newOptionsCount > 0){
-            int port = int.Parse(this._dropdown.options[0].text);
-            Debug.Log(string.Format("Setting default port: {0}", port));
-            HeartrateManager.Instance.Plugin.SetPort(port);
+        List<int> sortedPorts = new List<int>(HeartrateManager.Instance.Plugin.GetPorts().Keys);
+        sortedPorts.Sort();
+        RefreshValues(sortedPorts);
+        // Set display value to actual port
+        UpdateDisplay();
+    }
+
+    private void UpdateDisplay(){
+        int index = StringToIndex(HeartrateManager.Instance.Plugin.GetPort().ToString());
+        if(index > -1 && index < this._dropdown.options.Count){
+            this._dropdown.SetValueWithoutNotify(index);
         }
     }
 }

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -124,7 +124,7 @@ PlayerSettings:
     16:10: 0
     16:9: 0
     Others: 1
-  bundleVersion: 1.2.1
+  bundleVersion: 1.2.2
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -124,7 +124,7 @@ PlayerSettings:
     16:10: 0
     16:9: 0
     Others: 1
-  bundleVersion: 1.2.2
+  bundleVersion: 1.2.1e
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -124,7 +124,7 @@ PlayerSettings:
     16:10: 0
     16:9: 0
     Others: 1
-  bundleVersion: 1.2.1e
+  bundleVersion: 1.2.2
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0


### PR DESCRIPTION
This pull request addresses:

- Cases where the VTS Port was being permanently set to the wrong value if only one port was available, and it was not the default port.  The plugin will now first attempt to connect to the specified port, if that fails it will wait to discover a port via VTS port broadcasting, and if that takes too long and times out, it will attempt to connect to the default port (8001).
- Cases where the WebSocket Input API would be unable to read incoming heartrate data.
- Greatly reduced CPU overhead and socket bandwidth by migrating to the VTS Event API, reducing the number of API calls by over half.